### PR TITLE
Improve SWMR bootstrap and runtime dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
 
-add_executable(marshal src/marshal_main.cpp src/marshal_http.hpp src/marshal_ws.hpp src/marshal_state.hpp)
-target_link_libraries(marshal PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json)
+add_executable(marshal src/marshal_main.cpp src/marshal_http.hpp src/marshal_ws.hpp src/marshal_state.hpp src/swmr_writer.cpp)
+target_link_libraries(marshal PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target})
 
 
 add_executable(playback services/playback/playback_main.cpp)
@@ -72,7 +72,7 @@ add_executable(fk_client clients/fk_client/fk_client_main.cpp)
 target_link_libraries(fk_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json)
 
 add_executable(viz_client clients/viz_client/viz_client_main.cpp)
-target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json)
+target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target})
 
 add_executable(mk_mrd src/mk_mrd.cpp)
 target_link_libraries(mk_mrd PRIVATE ${ismrmrd_target} hdf5_serial)
@@ -100,6 +100,10 @@ if(BUILD_TESTING)
   add_executable(it_ws tests/test_ws_broadcast.cpp src/marshal_state.hpp)
   target_link_libraries(it_ws PRIVATE Catch2::Catch2WithMain Boost::system Threads::Threads nlohmann_json::nlohmann_json)
   add_test(NAME it_ws COMMAND it_ws)
+
+  add_executable(test_swmr tests/test_swmr_writer.cpp src/swmr_writer.cpp)
+  target_link_libraries(test_swmr PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${hdf5_target})
+  add_test(NAME test_swmr COMMAND test_swmr)
 endif()
 
 add_library(index_writer STATIC src/index_writer.cpp)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This keeps the data sink unambiguous: **one or the other**.
   - **MRD sink** (Live): writes `/data/mrd/<timestamp>_<seq>.mrd`, maintains `index.jsonl`, `latest.json`.
   - **Dumpbox sink** (Record): writes `/data/dumpbox/<SESSION>/files/*.mrd`, with session-scoped `index.jsonl`, `latest.json`.
 - 🔁 **HTTP playback** tool: re-POSTs a dumpbox session back to `/v1/mrd/ingest` to simulate the scanner; `marshal` (in MRD mode) rewrites fresh MRDs for clients.
+- 🔓 **SWMR MRD streaming**: `/v1/mrd/frame` appends reconstructed images into a live HDF5 dataset so readers can follow along via HDF5 Single-Writer-Multiple-Reader semantics.
 - 🧩 **Zero client code changes** between Live and Replay—clients always “read files.”
 - ⚙️ **Tiny footprint**: Boost.Asio/Beast + nlohmann/json; no heavy deps.
 
@@ -91,6 +92,31 @@ tail -n 5 ./data/mrd/index.jsonl || true
 cat ./data/mrd/latest.json
 ```
 
+#### Stream frames with SWMR
+
+```bash
+# Create a trio of demo frames (float32, 2 channels, 4x3 slice)
+python - <<'PY'
+import numpy as np
+for i, offset in enumerate([0, 100, 200]):
+    (np.arange(24, dtype=np.float32) + offset).tofile(f'frame{i}.bin')
+PY
+
+for f in frame0.bin frame1.bin frame2.bin; do
+  curl -fsS \
+    -H 'Content-Type: application/octet-stream' \
+    -H 'X-MRD-Stream: demo_stream' \
+    -H 'X-MRD-Dimensions: 4x3' \
+    -H 'X-MRD-Channels: 2' \
+    -H 'X-MRD-Datatype: float32' \
+    --data-binary @$f \
+    http://localhost:8080/v1/mrd/frame | jq
+done
+
+# The viz client opens the resulting MRD with HDF5 SWMR and prints frame counts
+./build/viz_client --ws ws://localhost:8090/ws --data ./data/mrd
+```
+
 ---
 
 ## Developer note: MRD ingestion helper
@@ -137,9 +163,15 @@ cat ./data/mrd/latest.json
 
 ## HTTP API
 
-- **`POST /v1/mrd/ingest`** — Body: MRD bytes (`application/octet-stream`)  
-  - **MRD mode:** writes to `/data/mrd`, updates global `index.jsonl`/`latest.json`.  
+- **`POST /v1/mrd/ingest`** — Body: MRD bytes (`application/octet-stream`)
+  - **MRD mode:** writes to `/data/mrd`, updates global `index.jsonl`/`latest.json`.
   - **Dumpbox mode:** writes to session under `/data/dumpbox/<SESSION>`, updates session `index.jsonl`/`latest.json`.
+- **`POST /v1/mrd/frame`** — Body: raw voxel bytes (`application/octet-stream`)
+  - `X-MRD-Stream`: logical identifier; the marshal will keep a matching `.mrd` file open
+  - `X-MRD-Dimensions`: spatial size as `XxY` or `XxYxZ`
+  - `X-MRD-Channels`: optional channel count (default `1`)
+  - `X-MRD-Datatype`: `float32` (default) or `uint16`
+  - Appends into the `/frames` dataset using HDF5 SWMR so readers can open the file while it grows
 - **`GET /health`** — returns `ok`.
 - **(If present) `GET /v1/mrd/since?ts=...&limit=...`** — convenience reader over `index.jsonl`.
 

--- a/README_MODE_A.md
+++ b/README_MODE_A.md
@@ -39,6 +39,24 @@ curl -fsS -H "Content-Type: application/octet-stream" \
   --data-binary @./data/mrd/sample_live_2.h5 \
   http://localhost:8080/v1/mrd/ingest | tee /dev/stderr
 
+# 5b) Append streaming frames into a live SWMR MRD (float32 4x3x1, 2 channels)
+python - <<'PY'
+import numpy as np
+for i, off in enumerate([0, 100, 200]):
+    (np.arange(24, dtype=np.float32) + off).tofile(f'frame_{i}.bin')
+PY
+
+for f in frame_0.bin frame_1.bin frame_2.bin; do
+  curl -fsS \
+    -H 'Content-Type: application/octet-stream' \
+    -H 'X-MRD-Stream: live_demo' \
+    -H 'X-MRD-Dimensions: 4x3' \
+    -H 'X-MRD-Channels: 2' \
+    -H 'X-MRD-Datatype: float32' \
+    --data-binary @$f \
+    http://localhost:8080/v1/mrd/frame | tee /dev/stderr
+done
+
 # 6) (Optional) WebSocket ingest smoke test (requires websocat)
 # Send the MRD payload as a single binary frame; the server will write a new file
 # and broadcast the ingest metadata back to any subscribers.

--- a/README_MODE_B.md
+++ b/README_MODE_B.md
@@ -42,6 +42,23 @@ curl -fsS -H "Content-Type: application/octet-stream" \
   --data-binary @./data/mrd/tmp_record_2.h5 \
   http://localhost:8080/v1/mrd/ingest | tee /dev/stderr
 
+# (Optional) Append live SWMR frames to the active dumpbox session
+python - <<'PY'
+import numpy as np
+for i, off in enumerate([0, 40, 80]):
+    (np.arange(24, dtype=np.float32) + off).tofile(f'dumpbox_frame_{i}.bin')
+PY
+
+for f in dumpbox_frame_0.bin dumpbox_frame_1.bin dumpbox_frame_2.bin; do
+  curl -fsS \
+    -H 'Content-Type: application/octet-stream' \
+    -H 'X-MRD-Stream: dumpbox_demo' \
+    -H 'X-MRD-Dimensions: 4x3' \
+    -H 'X-MRD-Channels: 2' \
+    --data-binary @$f \
+    http://localhost:8080/v1/mrd/frame | tee /dev/stderr
+done
+
 # 6) Locate the newest dumpbox session (contains files/ + metadata)
 SESSION_DIR=""
 for _ in $(seq 1 25); do

--- a/clients/viz_client/viz_client_main.cpp
+++ b/clients/viz_client/viz_client_main.cpp
@@ -7,6 +7,8 @@
 #include <boost/beast/websocket.hpp>
 #include <nlohmann/json.hpp>
 #include <boost/beast/core/buffers_to_string.hpp>
+#include <hdf5.h>
+#include <vector>
 
 using json = nlohmann::json;
 namespace fs = std::filesystem;
@@ -20,6 +22,58 @@ static std::time_t file_time_to_time_t(std::filesystem::file_time_type t)
     const auto sctp = time_point_cast<system_clock::duration>(
         t - std::filesystem::file_time_type::clock::now() + system_clock::now());
     return system_clock::to_time_t(sctp);
+}
+
+static void inspect_swmr_file(const std::string &path)
+{
+    if (path.empty())
+        return;
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    if (fapl < 0)
+        return;
+    H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI);
+    hid_t file = H5Fopen(path.c_str(), H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+    H5Pclose(fapl);
+    if (file < 0)
+    {
+        std::cerr << "viz: unable to open SWMR file " << path << "\n";
+        return;
+    }
+    hid_t dset = H5Dopen2(file, "/frames", H5P_DEFAULT);
+    if (dset < 0)
+    {
+        std::cerr << "viz: /frames dataset missing in " << path << "\n";
+        H5Fclose(file);
+        return;
+    }
+    if (H5Drefresh(dset) < 0)
+    {
+        std::cerr << "viz: H5Drefresh failed for " << path << "\n";
+    }
+    hid_t space = H5Dget_space(dset);
+    if (space < 0)
+    {
+        std::cerr << "viz: cannot read dataset space" << std::endl;
+        H5Dclose(dset);
+        H5Fclose(file);
+        return;
+    }
+    int rank = H5Sget_simple_extent_ndims(space);
+    std::vector<hsize_t> dims(rank, 0);
+    if (rank > 0)
+        H5Sget_simple_extent_dims(space, dims.data(), nullptr);
+    H5Sclose(space);
+    H5Dclose(dset);
+    H5Fclose(file);
+
+    if (dims.size() == 5)
+    {
+        std::cout << "viz swmr: frames=" << dims[0]
+                  << " channels=" << dims[1]
+                  << " shape=" << dims[4] << "x" << dims[3] << "x" << dims[2]
+                  << "\n";
+    }
 }
 
 int main(int argc, char **argv)
@@ -50,13 +104,23 @@ int main(int argc, char **argv)
         std::time_t last = 0;
         while (true) {
             try {
-                if (fs::exists(latest)) {
+                    if (fs::exists(latest)) {
                    // auto wt = decltype(fs::last_write_time(latest))::clock::to_time_t(fs::last_write_time(latest));
                    auto wt = file_time_to_time_t(fs::last_write_time(latest));
                    if (wt != last) {
                         std::ifstream lf(latest);
                         json lj; lf >> lj;
                         std::cout << "viz latest=" << lj.dump() << "\n";
+                        if (lj.contains("frame_index") && lj.contains("path"))
+                        {
+                            try
+                            {
+                                inspect_swmr_file(lj["path"].get<std::string>());
+                            }
+                            catch (...)
+                            {
+                            }
+                        }
                         last = wt;
                     }
                 }
@@ -97,7 +161,19 @@ int main(int argc, char **argv)
             buf.consume(buf.size());
             auto j = json::parse(s, nullptr, false);
             if (j.is_object())
+            {
                 std::cout << "viz ws: " << j.dump() << "\n";
+                if (j.contains("frame_index") && j.contains("path"))
+                {
+                    try
+                    {
+                        inspect_swmr_file(j["path"].get<std::string>());
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+            }
         }
     }
     catch (const std::exception &e)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,6 +107,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   lld \
   libpugixml1v5 \
   libhdf5-103-1 \
+  libhdf5-hl-200 \
   libboost-system1.83.0 libboost-filesystem1.83.0 libboost-thread1.83.0 libboost-program-options1.83.0 \
   util-linux \
   bsdmainutils \

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,44 @@
+# Architecture Overview
+
+CWRU Data Marshal is a single-process hub that accepts reconstructed MRI data
+and pose updates over HTTP/WebSocket, persists them on disk, and fans metadata
+out to connected clients. The core components are:
+
+- **HTTP server (`HttpServer`)** — Handles REST endpoints for MRD ingest,
+  SWMR frame streaming, pose updates, and metadata queries.
+- **WebSocket server (`WsServer`)** — Broadcasts ingest and pose events to
+  subscribed clients.
+- **Storage helpers (`mrd_io.hpp`)** — Provide atomic file writes, index and
+  metadata maintenance, and sink selection logic for MRD vs. dumpbox modes.
+- **SWMR manager (`SwmrManager`)** — Manages extendible HDF5 datasets that stay
+  open while new frames arrive.
+
+## Request flow
+
+1. **Ingesting full MRDs** (`POST /v1/mrd/ingest`)
+   - The HTTP handler forwards the payload to `mrd::ingest_payload()` which
+     writes the file atomically into either `/data/mrd` (live) or the active
+     dumpbox session, updates `index.jsonl`/`latest.json`, and emits a WebSocket
+     notification.
+2. **Streaming frames** (`POST /v1/mrd/frame`)
+   - The handler validates stream headers, then asks `SwmrManager` to append the
+     frame into an HDF5 dataset. `SwmrManager` ensures one open file per stream
+     and uses `SwmrFile` to extend the `/frames` dataset via HDF5 SWMR APIs.
+   - Each append logs into the same index files as full MRD ingests so clients
+     have a unified view of activity.
+3. **Poses and telemetry**
+   - Pose updates update the in-memory `PoseStore` and immediately broadcast.
+
+## SWMR file layout
+
+Each SWMR stream creates a file named
+`<timestamp>_<sanitized-stream>.mrd` inside the active sink. The file contains a
+single dataset `/frames` with dimensions `[frames, channels, z, y, x]` and
+attributes describing voxel type and geometry. Writers call `H5Fstart_swmr_write`
+once at creation and `H5Dflush`/`H5Fflush` after each frame so SWMR readers can
+see consistent snapshots without waiting for the file to close.
+
+`viz_client` demonstrates the reader side by opening the MRD file with
+`H5F_ACC_SWMR_READ` whenever `index.jsonl` advertises a new frame. Because the
+same index files record both full ingests and SWMR frames, existing tailing
+clients continue to work.

--- a/docs/USAGE_WITH_CLIENTS.md
+++ b/docs/USAGE_WITH_CLIENTS.md
@@ -116,6 +116,31 @@ The WebSocket fan-out will emit pose notifications that `viz_client` will show
 immediately. You can re-run `fk_client` any time to emulate the scanner pose
 stream.
 
+### 5b. Stream reconstructed frames via SWMR
+
+The marshal can now append raw voxel frames into a live MRD file while
+`viz_client` observes the growth.
+
+```bash
+python - <<'PY'
+import numpy as np
+for i, off in enumerate([0, 32, 64]):
+    (np.linspace(0, 1, 32, dtype=np.float32) + off).tofile(f'stream_frame_{i}.bin')
+PY
+
+for f in stream_frame_0.bin stream_frame_1.bin stream_frame_2.bin; do
+  curl -fsS \
+    -H 'Content-Type: application/octet-stream' \
+    -H 'X-MRD-Stream: viz_demo' \
+    -H 'X-MRD-Dimensions: 8x4' \
+    -H 'X-MRD-Channels: 1' \
+    --data-binary @$f \
+    http://localhost:8080/v1/mrd/frame | tee /dev/stderr
+done
+```
+
+`viz_client` will print the new frame count immediately thanks to HDF5 SWMR.
+
 ### 6. Inspect live-mode outputs
 
 ```bash

--- a/include/mrd_io.hpp
+++ b/include/mrd_io.hpp
@@ -68,6 +68,41 @@ inline void ensure_dir(const std::filesystem::path &p)
     }
 }
 
+struct SinkPaths
+{
+    std::filesystem::path sink_root;
+    std::filesystem::path index_root;
+};
+
+inline SinkPaths resolve_sink_paths(MarshalState &state)
+{
+    namespace fs = std::filesystem;
+    SinkPaths paths;
+
+    fs::path mrd_root = fs::path(state.data_dir) / "mrd";
+    ensure_dir(mrd_root);
+
+    if (state.sink_mode == SinkMode::MRD)
+    {
+        paths.sink_root = mrd_root;
+        paths.index_root = mrd_root;
+    }
+    else
+    {
+        std::string session = state.dumpbox_session.empty() ? iso8601_now_ms() : state.dumpbox_session;
+        fs::path session_dir = fs::path(state.dumpbox_root) / session;
+        paths.index_root = session_dir;
+        paths.sink_root = session_dir / "files";
+        std::error_code ec_mk;
+        std::filesystem::create_directories(paths.sink_root, ec_mk);
+        if (ec_mk)
+            throw std::runtime_error("ensure dumpbox sink failed: " + ec_mk.message());
+        state.dumpbox_session = session;
+    }
+
+    return paths;
+}
+
 inline void write_atomic(const std::filesystem::path &dst, const void *data, size_t n)
 {
     namespace fs = std::filesystem;
@@ -163,34 +198,16 @@ inline nlohmann::json ingest_payload(MarshalState &state,
 {
     namespace fs = std::filesystem;
 
-    fs::path mrd_root = fs::path(state.data_dir) / "mrd";
-    ensure_dir(mrd_root);
-
     const std::string ts = iso8601_now_ms();
     const uint64_t seq = ingest_sequence().fetch_add(1);
 
     std::ostringstream name;
     name << ts << '_' << std::setw(6) << std::setfill('0') << seq << ".mrd";
 
-    fs::path sink_root;
-    fs::path index_root;
-    if (state.sink_mode == SinkMode::MRD)
-    {
-        sink_root = mrd_root;
-        index_root = mrd_root;
-    }
-    else
-    {
-        std::string session = state.dumpbox_session.empty() ? iso8601_now_ms() : state.dumpbox_session;
-        fs::path session_dir = fs::path(state.dumpbox_root) / session;
-        index_root = session_dir;
-        sink_root = session_dir / "files";
-        std::error_code ec_mk;
-        std::filesystem::create_directories(sink_root, ec_mk);
-        if (ec_mk)
-            throw std::runtime_error("ensure dumpbox sink failed: " + ec_mk.message());
-        state.dumpbox_session = session;
-    }
+    SinkPaths paths = resolve_sink_paths(state);
+
+    fs::path sink_root = paths.sink_root;
+    fs::path index_root = paths.index_root;
 
     fs::path out_path = sink_root / name.str();
     write_atomic(out_path, data, size);

--- a/include/swmr_writer.hpp
+++ b/include/swmr_writer.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <hdf5.h>
+
+#include <nlohmann/json.hpp>
+
+#include "marshal_state.hpp"
+
+namespace mrd
+{
+
+enum class ElementType
+{
+    Float32,
+    UInt16
+};
+
+struct StreamDimensions
+{
+    std::array<hsize_t, 3> spatial{}; // {x, y, z}
+    hsize_t channels{1};
+};
+
+struct SwmrFrameResult
+{
+    std::filesystem::path file_path;
+    std::string stream_id;
+    std::string timestamp;
+    uint64_t frame_index{0};
+    size_t bytes{0};
+    ElementType element_type{ElementType::Float32};
+    StreamDimensions dims;
+};
+
+class SwmrFile
+{
+  public:
+    SwmrFile(const std::filesystem::path &path,
+             const std::string &stream_id,
+             ElementType type,
+             const StreamDimensions &dims);
+    ~SwmrFile();
+
+    SwmrFile(const SwmrFile &) = delete;
+    SwmrFile &operator=(const SwmrFile &) = delete;
+
+    SwmrFrameResult append_frame(const void *data, size_t bytes);
+
+    const std::filesystem::path &path() const noexcept { return path_; }
+    ElementType element_type() const noexcept { return type_; }
+    const StreamDimensions &dims() const noexcept { return dims_; }
+    uint64_t frame_count() const noexcept { return frames_; }
+
+  private:
+    std::filesystem::path path_;
+    std::string stream_id_;
+    ElementType type_;
+    StreamDimensions dims_;
+    hid_t file_{-1};
+    hid_t dataset_{-1};
+    uint64_t frames_{0};
+    std::mutex write_mutex_;
+
+    void open();
+    void close();
+    size_t expected_bytes() const;
+};
+
+class SwmrManager
+{
+  public:
+    explicit SwmrManager(MarshalState &state);
+
+    SwmrManager(const SwmrManager &) = delete;
+    SwmrManager &operator=(const SwmrManager &) = delete;
+
+    SwmrFrameResult append_frame(const std::string &stream_id,
+                                 const StreamDimensions &dims,
+                                 ElementType type,
+                                 const void *data,
+                                 size_t bytes);
+
+  private:
+    struct StreamState
+    {
+        std::unique_ptr<SwmrFile> file;
+        std::mutex mutex;
+        StreamDimensions dims;
+        ElementType type{ElementType::Float32};
+    };
+
+    MarshalState &state_;
+    std::mutex map_mutex_;
+    std::unordered_map<std::string, std::shared_ptr<StreamState>> streams_;
+
+    std::shared_ptr<StreamState> ensure_stream(const std::string &stream_id,
+                                               const StreamDimensions &dims,
+                                               ElementType type,
+                                               const std::filesystem::path &sink_root);
+    static std::string sanitize_stream(const std::string &stream_id);
+    static std::string element_type_string(ElementType t);
+    nlohmann::json make_entry_json(const SwmrFrameResult &result) const;
+};
+
+ElementType parse_element_type(const std::string &value);
+std::string element_type_to_string(ElementType type);
+
+} // namespace mrd

--- a/src/marshal_http.hpp
+++ b/src/marshal_http.hpp
@@ -21,16 +21,20 @@
 #include <nlohmann/json.hpp>
 #include "mrd_io.hpp"
 
+#include <array>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <memory>
-#include <string>
-#include <chrono>
 #include <iomanip>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <vector>
+#include <cctype>
 
 #include "marshal_state.hpp"
 #include "common/pose.hpp" // Pose, PoseStore, pose_to_json
+#include "swmr_writer.hpp"
 
 namespace http = boost::beast::http;
 namespace fs = std::filesystem;
@@ -266,6 +270,113 @@ private:
                                  .dump();
                 res.prepare_payload();
                 return respond(std::move(res));
+            }
+
+            // POST /v1/mrd/frame  (append streaming frame to SWMR-managed MRD)
+            if (req.method() == http::verb::post && req.target() == "/v1/mrd/frame")
+            {
+                using namespace std::string_literals;
+                auto stream_header = std::string(req["X-MRD-Stream"]);
+                auto dims_header = std::string(req["X-MRD-Dimensions"]);
+                auto dtype_header = std::string(req["X-MRD-Datatype"]);
+                auto channels_header = std::string(req["X-MRD-Channels"]);
+
+                if (!state.swmr)
+                {
+                    http::response<http::string_body> res{http::status::service_unavailable, req.version()};
+                    res.set(http::field::content_type, "application/json");
+                    res.body() = json{{"error", "SWMR not initialised"}}.dump();
+                    res.prepare_payload();
+                    return respond(std::move(res));
+                }
+
+                auto parse_dims = [](const std::string &value) -> std::array<uint64_t, 3>
+                {
+                    std::array<uint64_t, 3> dims{0, 0, 1};
+                    std::vector<std::string> parts;
+                    std::string current;
+                    for (char c : value)
+                    {
+                        if (c == 'x' || c == 'X' || c == ',' || std::isspace(static_cast<unsigned char>(c)))
+                        {
+                            if (!current.empty())
+                            {
+                                parts.push_back(current);
+                                current.clear();
+                            }
+                        }
+                        else
+                        {
+                            current.push_back(c);
+                        }
+                    }
+                    if (!current.empty())
+                        parts.push_back(current);
+                    if (parts.size() < 2 || parts.size() > 3)
+                        throw std::runtime_error("X-MRD-Dimensions must contain 2 or 3 values");
+
+                    dims[0] = std::stoull(parts[0]);
+                    dims[1] = std::stoull(parts[1]);
+                    if (parts.size() == 3)
+                        dims[2] = std::stoull(parts[2]);
+                    if (dims[0] == 0 || dims[1] == 0)
+                        throw std::runtime_error("dimensions must be non-zero");
+                    if (dims[2] == 0)
+                        dims[2] = 1;
+                    return dims;
+                };
+
+                try
+                {
+                    if (stream_header.empty())
+                        throw std::runtime_error("missing X-MRD-Stream header");
+                    if (dims_header.empty())
+                        throw std::runtime_error("missing X-MRD-Dimensions header");
+
+                    auto dims_vec = parse_dims(dims_header);
+                    mrd::StreamDimensions dims;
+                    dims.spatial = {static_cast<hsize_t>(dims_vec[0]), static_cast<hsize_t>(dims_vec[1]), static_cast<hsize_t>(dims_vec[2])};
+                    if (!channels_header.empty())
+                    {
+                        dims.channels = static_cast<hsize_t>(std::stoull(channels_header));
+                        if (dims.channels == 0)
+                            throw std::runtime_error("channels must be >= 1");
+                    }
+
+                    auto dtype = dtype_header.empty() ? "float32"s : dtype_header;
+                    auto element_type = mrd::parse_element_type(dtype);
+
+                    const std::string &body = req.body();
+                    if (body.empty())
+                        throw std::runtime_error("empty body");
+
+                    auto result = state.swmr->append_frame(stream_header, dims, element_type, body.data(), body.size());
+
+                    json resp = {
+                        {"status", "ok"},
+                        {"path", result.file_path.string()},
+                        {"stream", result.stream_id},
+                        {"frame_index", result.frame_index},
+                        {"ts", result.timestamp},
+                        {"dims", {result.dims.spatial[0], result.dims.spatial[1], result.dims.spatial[2]}},
+                        {"channels", result.dims.channels},
+                        {"datatype", mrd::element_type_to_string(result.element_type)},
+                        {"size_bytes", result.bytes}};
+
+                    http::response<http::string_body> res{http::status::ok, req.version()};
+                    res.set(http::field::content_type, "application/json");
+                    res.body() = resp.dump();
+                    res.prepare_payload();
+                    return respond(std::move(res));
+                }
+                catch (const std::exception &e)
+                {
+                    http::response<http::string_body> res{http::status::bad_request, req.version()};
+                    res.set(http::field::content_type, "application/json");
+                    res.body() = json{{"error", e.what()}}.dump();
+                    res.prepare_payload();
+                    return respond(std::move(res));
+                }
             }
 
             // POST /v1/mrd/ingest  (writes ${data_dir}/mrd/*.mrd and updates index/latest)

--- a/src/marshal_main.cpp
+++ b/src/marshal_main.cpp
@@ -17,6 +17,7 @@
 #include "marshal_ws.hpp"
 #include "marshal_state.hpp"
 #include "mrd_io.hpp"
+#include "swmr_writer.hpp"
 
 namespace fs = std::filesystem;
 
@@ -91,6 +92,8 @@ int main(int argc, char **argv)
                       << " failed: " << ec.message() << "\n";
         }
     }
+
+    state.swmr = std::make_shared<mrd::SwmrManager>(state);
 
     // Networking endpoints
     boost::asio::ip::tcp::endpoint http_ep{boost::asio::ip::make_address(http_host), http_port};

--- a/src/marshal_state.hpp
+++ b/src/marshal_state.hpp
@@ -20,6 +20,11 @@
 #include <boost/asio.hpp>
 #include <nlohmann/json.hpp>
 #include "common/pose.hpp"
+
+namespace mrd
+{
+class SwmrManager;
+}
 enum class SinkMode
 {
     MRD,
@@ -59,4 +64,6 @@ struct MarshalState
     // Optional topic-based emit hook (set by WsServer on init).
     std::function<void(const std::string &, const std::string &topic)> ws_emit_topic =
         [](const std::string &, const std::string &) {};
+
+    std::shared_ptr<mrd::SwmrManager> swmr;
 };

--- a/src/swmr_writer.cpp
+++ b/src/swmr_writer.cpp
@@ -1,0 +1,380 @@
+#include "swmr_writer.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <stdexcept>
+
+#include "mrd_io.hpp"
+
+namespace mrd
+{
+namespace
+{
+size_t element_size(ElementType type)
+{
+    switch (type)
+    {
+    case ElementType::Float32:
+        return sizeof(float);
+    case ElementType::UInt16:
+        return sizeof(uint16_t);
+    }
+    throw std::runtime_error("unsupported element type");
+}
+
+hid_t element_hdf_type(ElementType type)
+{
+    switch (type)
+    {
+    case ElementType::Float32:
+        return H5T_IEEE_F32LE;
+    case ElementType::UInt16:
+        return H5T_STD_U16LE;
+    }
+    throw std::runtime_error("unsupported element type");
+}
+
+} // namespace
+
+SwmrFile::SwmrFile(const std::filesystem::path &path,
+                   const std::string &stream_id,
+                   ElementType type,
+                   const StreamDimensions &dims)
+    : path_(path), stream_id_(stream_id), type_(type), dims_(dims)
+{
+    if (dims_.spatial[0] == 0 || dims_.spatial[1] == 0 || dims_.channels == 0)
+        throw std::runtime_error("invalid SWMR dimensions");
+    open();
+}
+
+SwmrFile::~SwmrFile()
+{
+    close();
+}
+
+void SwmrFile::open()
+{
+    namespace fs = std::filesystem;
+    fs::create_directories(path_.parent_path());
+
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    if (fapl < 0)
+        throw std::runtime_error("H5Pcreate failed");
+
+    if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
+    {
+        H5Pclose(fapl);
+        throw std::runtime_error("H5Pset_libver_bounds failed");
+    }
+
+    if (H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI) < 0)
+    {
+        H5Pclose(fapl);
+        throw std::runtime_error("H5Pset_fclose_degree failed");
+    }
+
+    file_ = H5Fcreate(path_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    H5Pclose(fapl);
+    if (file_ < 0)
+        throw std::runtime_error("H5Fcreate failed");
+
+    const hsize_t z = dims_.spatial[2] ? dims_.spatial[2] : 1;
+    hsize_t initial_dims[5] = {0, dims_.channels, z, dims_.spatial[1], dims_.spatial[0]};
+    hsize_t max_dims[5] = {H5S_UNLIMITED, dims_.channels, z, dims_.spatial[1], dims_.spatial[0]};
+    hsize_t chunk[5] = {1, dims_.channels, z, dims_.spatial[1], dims_.spatial[0]};
+
+    hid_t space = H5Screate_simple(5, initial_dims, max_dims);
+    if (space < 0)
+    {
+        close();
+        throw std::runtime_error("H5Screate_simple failed");
+    }
+
+    hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+    if (dcpl < 0)
+    {
+        H5Sclose(space);
+        close();
+        throw std::runtime_error("H5Pcreate (dcpl) failed");
+    }
+
+    if (H5Pset_chunk(dcpl, 5, chunk) < 0 ||
+        H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0 ||
+        H5Pset_alloc_time(dcpl, H5D_ALLOC_TIME_EARLY) < 0)
+    {
+        H5Pclose(dcpl);
+        H5Sclose(space);
+        close();
+        throw std::runtime_error("chunk configuration failed");
+    }
+
+    dataset_ = H5Dcreate2(file_, "/frames", element_hdf_type(type_), space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    H5Pclose(dcpl);
+    H5Sclose(space);
+    if (dataset_ < 0)
+    {
+        close();
+        throw std::runtime_error("H5Dcreate2 failed");
+    }
+
+    // Store simple metadata so readers know the layout
+    unsigned long long dims_attr[3] = {
+        static_cast<unsigned long long>(dims_.spatial[0]),
+        static_cast<unsigned long long>(dims_.spatial[1]),
+        static_cast<unsigned long long>(z)};
+    hsize_t attr_dims[1] = {3};
+    hid_t attr_space = H5Screate_simple(1, attr_dims, nullptr);
+    hid_t attr = H5Acreate2(dataset_, "spatial_dims", H5T_STD_U64LE, attr_space, H5P_DEFAULT, H5P_DEFAULT);
+    if (attr >= 0)
+    {
+        H5Awrite(attr, H5T_NATIVE_ULLONG, dims_attr);
+        H5Aclose(attr);
+    }
+    H5Sclose(attr_space);
+
+    attr_space = H5Screate(H5S_SCALAR);
+    attr = H5Acreate2(dataset_, "channels", H5T_STD_U64LE, attr_space, H5P_DEFAULT, H5P_DEFAULT);
+    if (attr >= 0)
+    {
+        unsigned long long ch = static_cast<unsigned long long>(dims_.channels);
+        H5Awrite(attr, H5T_NATIVE_ULLONG, &ch);
+        H5Aclose(attr);
+    }
+    H5Sclose(attr_space);
+
+    attr_space = H5Screate(H5S_SCALAR);
+    hid_t str_type = H5Tcopy(H5T_C_S1);
+    auto et = element_type_to_string(type_);
+    H5Tset_size(str_type, et.size() + 1);
+    H5Tset_strpad(str_type, H5T_STR_NULLTERM);
+    attr = H5Acreate2(dataset_, "element_type", str_type, attr_space, H5P_DEFAULT, H5P_DEFAULT);
+    if (attr >= 0)
+    {
+        H5Awrite(attr, str_type, et.c_str());
+        H5Aclose(attr);
+    }
+    H5Tclose(str_type);
+    H5Sclose(attr_space);
+
+    if (H5Fflush(file_, H5F_SCOPE_GLOBAL) < 0)
+    {
+        close();
+        throw std::runtime_error("H5Fflush failed before SWMR start");
+    }
+
+    if (H5Fstart_swmr_write(file_) < 0)
+    {
+        close();
+        throw std::runtime_error("H5Fstart_swmr_write failed");
+    }
+
+    H5Fflush(file_, H5F_SCOPE_GLOBAL);
+}
+
+void SwmrFile::close()
+{
+    if (dataset_ >= 0)
+    {
+        H5Dclose(dataset_);
+        dataset_ = -1;
+    }
+    if (file_ >= 0)
+    {
+        H5Fflush(file_, H5F_SCOPE_GLOBAL);
+        H5Fclose(file_);
+        file_ = -1;
+    }
+}
+
+size_t SwmrFile::expected_bytes() const
+{
+    return static_cast<size_t>(dims_.spatial[0]) * static_cast<size_t>(dims_.spatial[1]) *
+           static_cast<size_t>(dims_.spatial[2] ? dims_.spatial[2] : 1) *
+           static_cast<size_t>(dims_.channels) * element_size(type_);
+}
+
+SwmrFrameResult SwmrFile::append_frame(const void *data, size_t bytes)
+{
+    std::lock_guard<std::mutex> guard(write_mutex_);
+    const size_t need = expected_bytes();
+    if (bytes != need)
+        throw std::runtime_error("frame payload size mismatch");
+
+    hsize_t new_dims[5] = {frames_ + 1, dims_.channels, dims_.spatial[2] ? dims_.spatial[2] : 1,
+                           dims_.spatial[1], dims_.spatial[0]};
+    if (H5Dset_extent(dataset_, new_dims) < 0)
+        throw std::runtime_error("H5Dset_extent failed");
+
+    hid_t filespace = H5Dget_space(dataset_);
+    if (filespace < 0)
+        throw std::runtime_error("H5Dget_space failed");
+
+    hsize_t start[5] = {frames_, 0, 0, 0, 0};
+    hsize_t count[5] = {1, dims_.channels, new_dims[2], new_dims[3], new_dims[4]};
+    if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, nullptr, count, nullptr) < 0)
+    {
+        H5Sclose(filespace);
+        throw std::runtime_error("H5Sselect_hyperslab failed");
+    }
+
+    hid_t memspace = H5Screate_simple(5, count, nullptr);
+    if (memspace < 0)
+    {
+        H5Sclose(filespace);
+        throw std::runtime_error("H5Screate_simple (mem) failed");
+    }
+
+    if (H5Dwrite(dataset_, element_hdf_type(type_), memspace, filespace, H5P_DEFAULT, data) < 0)
+    {
+        H5Sclose(memspace);
+        H5Sclose(filespace);
+        throw std::runtime_error("H5Dwrite failed");
+    }
+
+    H5Sclose(memspace);
+    H5Sclose(filespace);
+
+    if (H5Dflush(dataset_) < 0 || H5Fflush(file_, H5F_SCOPE_GLOBAL) < 0)
+        throw std::runtime_error("H5 flush failed");
+
+    SwmrFrameResult result;
+    result.file_path = path_;
+    result.stream_id = stream_id_;
+    result.frame_index = frames_;
+    result.bytes = bytes;
+    result.element_type = type_;
+    result.dims = dims_;
+    result.timestamp = iso8601_now_ms();
+
+    frames_++;
+    return result;
+}
+
+SwmrManager::SwmrManager(MarshalState &state)
+    : state_(state)
+{
+}
+
+std::shared_ptr<SwmrManager::StreamState> SwmrManager::ensure_stream(const std::string &stream_id,
+                                                                      const StreamDimensions &dims,
+                                                                      ElementType type,
+                                                                      const std::filesystem::path &sink_root)
+{
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    auto it = streams_.find(stream_id);
+    if (it != streams_.end())
+    {
+        auto state = it->second;
+        if (state->dims.spatial != dims.spatial || state->dims.channels != dims.channels || state->type != type)
+            throw std::runtime_error("stream dimensions/type mismatch");
+        return state;
+    }
+
+    auto clean = sanitize_stream(stream_id);
+    const std::string ts = iso8601_now_ms();
+    std::filesystem::path file_path = sink_root / (ts + "_" + clean + ".mrd");
+
+    auto state = std::make_shared<StreamState>();
+    state->dims = dims;
+    state->type = type;
+    state->file = std::make_unique<SwmrFile>(file_path, stream_id, type, dims);
+
+    streams_.emplace(stream_id, state);
+    return state;
+}
+
+SwmrFrameResult SwmrManager::append_frame(const std::string &stream_id,
+                                          const StreamDimensions &dims,
+                                          ElementType type,
+                                          const void *data,
+                                          size_t bytes)
+{
+    auto sink = resolve_sink_paths(state_);
+    auto stream_state = ensure_stream(stream_id, dims, type, sink.sink_root);
+
+    std::lock_guard<std::mutex> guard(stream_state->mutex);
+    auto result = stream_state->file->append_frame(data, bytes);
+
+    auto seq = ingest_sequence().fetch_add(1);
+    nlohmann::json entry = make_entry_json(result);
+    entry["seq"] = seq;
+
+    append_line(sink.index_root / "index.jsonl", entry.dump());
+    const std::string latest = entry.dump();
+    write_atomic(sink.index_root / "latest.json", latest.data(), latest.size());
+
+    try
+    {
+        state_.ws_emit(entry.dump());
+        state_.ws_emit_topic(entry.dump(), "mrd.swmr");
+    }
+    catch (...)
+    {
+    }
+
+    return result;
+}
+
+std::string SwmrManager::sanitize_stream(const std::string &stream_id)
+{
+    std::string out;
+    out.reserve(stream_id.size());
+    for (char c : stream_id)
+    {
+        if (std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_')
+            out.push_back(c);
+        else
+            out.push_back('_');
+    }
+    if (out.empty())
+        out = "stream";
+    return out;
+}
+
+std::string SwmrManager::element_type_string(ElementType t)
+{
+    return element_type_to_string(t);
+}
+
+nlohmann::json SwmrManager::make_entry_json(const SwmrFrameResult &result) const
+{
+    nlohmann::json dims_json = {
+        {"x", result.dims.spatial[0]},
+        {"y", result.dims.spatial[1]},
+        {"z", result.dims.spatial[2] ? result.dims.spatial[2] : 1},
+        {"channels", result.dims.channels}};
+
+    return {
+        {"type", "mrd.swmr"},
+        {"path", result.file_path.string()},
+        {"stream", result.stream_id},
+        {"ts", result.timestamp},
+        {"frame_index", result.frame_index},
+        {"element_type", element_type_string(result.element_type)},
+        {"dims", dims_json},
+        {"size_bytes", result.bytes}};
+}
+
+ElementType parse_element_type(const std::string &value)
+{
+    if (value == "float32" || value == "float" || value == "f32")
+        return ElementType::Float32;
+    if (value == "uint16" || value == "u16")
+        return ElementType::UInt16;
+    throw std::runtime_error("unsupported element type: " + value);
+}
+
+std::string element_type_to_string(ElementType type)
+{
+    switch (type)
+    {
+    case ElementType::Float32:
+        return "float32";
+    case ElementType::UInt16:
+        return "uint16";
+    }
+    return "unknown";
+}
+
+} // namespace mrd

--- a/tests/test_swmr_writer.cpp
+++ b/tests/test_swmr_writer.cpp
@@ -1,0 +1,85 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include <filesystem>
+#include <vector>
+#include <random>
+#include <string>
+#include <hdf5.h>
+
+#include "swmr_writer.hpp"
+#include "mrd_io.hpp"
+
+namespace fs = std::filesystem;
+
+static std::string unique_temp_dir()
+{
+    auto base = fs::temp_directory_path();
+    std::string name = "cwru_marshal_test_" + std::to_string(std::random_device{}());
+    fs::path full = base / name;
+    fs::create_directories(full);
+    return full.string();
+}
+
+TEST_CASE("SWMR writer appends frames visible to readers", "[swmr]")
+{
+    std::string temp = unique_temp_dir();
+    fs::path data_dir = fs::path(temp) / "data";
+    fs::create_directories(data_dir / "mrd");
+
+    MarshalState state;
+    state.data_dir = data_dir.string();
+    state.sink_mode = SinkMode::MRD;
+    state.ws_emit = [](const std::string &) {};
+    state.ws_emit_topic = [](const std::string &, const std::string &) {};
+
+    mrd::SwmrManager mgr(state);
+
+    mrd::StreamDimensions dims;
+    dims.spatial = {4, 3, 1};
+    dims.channels = 2;
+
+    const size_t elements = static_cast<size_t>(dims.spatial[0]) * dims.spatial[1] * dims.channels;
+    std::vector<float> frame1(elements, 1.5f);
+    std::vector<float> frame2(elements, 2.5f);
+
+    auto result1 = mgr.append_frame("streamA", dims, mrd::ElementType::Float32, frame1.data(), frame1.size() * sizeof(float));
+    REQUIRE(result1.frame_index == 0);
+
+    auto result2 = mgr.append_frame("streamA", dims, mrd::ElementType::Float32, frame2.data(), frame2.size() * sizeof(float));
+    REQUIRE(result2.frame_index == 1);
+    REQUIRE(result1.file_path == result2.file_path);
+
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    REQUIRE(fapl >= 0);
+    H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI);
+    hid_t file = H5Fopen(result2.file_path.c_str(), H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+    H5Pclose(fapl);
+    REQUIRE(file >= 0);
+
+    hid_t dset = H5Dopen2(file, "/frames", H5P_DEFAULT);
+    REQUIRE(dset >= 0);
+    hid_t space = H5Dget_space(dset);
+    REQUIRE(space >= 0);
+    hsize_t dims_out[5] = {0};
+    H5Sget_simple_extent_dims(space, dims_out, nullptr);
+    CHECK(dims_out[0] == 2);
+    CHECK(dims_out[1] == dims.channels);
+    CHECK(dims_out[3] == dims.spatial[1]);
+    CHECK(dims_out[4] == dims.spatial[0]);
+
+    std::vector<float> readback(elements * 2);
+    hid_t memspace = H5Screate_simple(5, dims_out, nullptr);
+    REQUIRE(memspace >= 0);
+    REQUIRE(H5Dread(dset, H5T_IEEE_F32LE, memspace, space, H5P_DEFAULT, readback.data()) >= 0);
+    H5Sclose(memspace);
+    H5Sclose(space);
+    H5Dclose(dset);
+    H5Fclose(file);
+
+    for (size_t i = 0; i < elements; ++i)
+    {
+        CHECK(readback[i] == Catch::Approx(frame1[i]));
+        CHECK(readback[i + elements] == Catch::Approx(frame2[i]));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure SWMR metadata is flushed before enabling writer mode and size the element-type attribute correctly
- refresh SWMR datasets in the viz client before inspecting frame dimensions
- include the high-level HDF5 runtime library in the docker image for SWMR readers

## Testing
- cmake --build build
- ctest

------
https://chatgpt.com/codex/tasks/task_e_68e4544e34e483329e6eb8f166c4a4f3