### PR TITLE
Default to ISMRMRD SWMR streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,6 @@ data/
 
 # Docs
 /docs/*
+!/docs/ARCHITECTURE.md
 !/docs/USAGE_WITH_CLIENTS.md
+!/docs/API_REFERENCE.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
 
-add_executable(marshal src/marshal_main.cpp src/marshal_http.hpp src/marshal_ws.hpp src/marshal_state.hpp)
-target_link_libraries(marshal PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json)
+add_executable(marshal src/marshal_main.cpp src/marshal_http.hpp src/marshal_ws.hpp src/marshal_state.hpp src/swmr_writer.cpp)
+target_link_libraries(marshal PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target})
 
 
 add_executable(playback services/playback/playback_main.cpp)
@@ -72,7 +72,7 @@ add_executable(fk_client clients/fk_client/fk_client_main.cpp)
 target_link_libraries(fk_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json)
 
 add_executable(viz_client clients/viz_client/viz_client_main.cpp)
-target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json)
+target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target})
 
 add_executable(mk_mrd src/mk_mrd.cpp)
 target_link_libraries(mk_mrd PRIVATE ${ismrmrd_target} hdf5_serial)
@@ -100,6 +100,10 @@ if(BUILD_TESTING)
   add_executable(it_ws tests/test_ws_broadcast.cpp src/marshal_state.hpp)
   target_link_libraries(it_ws PRIVATE Catch2::Catch2WithMain Boost::system Threads::Threads nlohmann_json::nlohmann_json)
   add_test(NAME it_ws COMMAND it_ws)
+
+  add_executable(test_swmr tests/test_swmr_writer.cpp src/swmr_writer.cpp)
+  target_link_libraries(test_swmr PRIVATE Catch2::Catch2WithMain nlohmann_json::nlohmann_json ${hdf5_target})
+  add_test(NAME test_swmr COMMAND test_swmr)
 endif()
 
 add_library(index_writer STATIC src/index_writer.cpp)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,59 @@
 # CWRU Data Marshal
 
-**What it is.** A tiny, fast HTTP/WS hub for reconstructed MRI data (ISMRMRD). It runs in exactly one of two modes:
+The marshal is a tiny, fast HTTP/WebSocket hub for reconstructed MRI data (ISMRMRD).
+It always runs in exactly **one** of two modes:
 
-- **Mode A — Live file access:** scanner → `marshal` → **MRD files** → clients read files  
-- **Mode B — Record → Replay:**  
-  - **Record now:** scanner → `marshal` → **dumpbox session** (no `/data/mrd` writes)  
-  - **Replay later:** `playback` → `marshal` → **MRD files** → clients read files (same interface as live)
+- **Mode A – Live file access:** scanner → `marshal` → **MRD files** → clients read files.
+- **Mode B – Record → Replay:**
+  - **Record now:** scanner → `marshal` → **dumpbox session** (no `/data/mrd` writes).
+  - **Replay later:** `playback` → `marshal` → **MRD files** → clients read files using the same interface as live.
 
-This keeps the data sink unambiguous: **one or the other**.
+Keeping the sink explicit makes operations predictable, observability trivial, and
+failure handling much easier.
 
 ---
 
-## Features
+## Why you might want this
 
-- 🚦 **Two explicit sinks**
-  - **MRD sink** (Live): writes `/data/mrd/<timestamp>_<seq>.mrd`, maintains `index.jsonl`, `latest.json`.
-  - **Dumpbox sink** (Record): writes `/data/dumpbox/<SESSION>/files/*.mrd`, with session-scoped `index.jsonl`, `latest.json`.
-- 🔁 **HTTP playback** tool: re-POSTs a dumpbox session back to `/v1/mrd/ingest` to simulate the scanner; `marshal` (in MRD mode) rewrites fresh MRDs for clients.
-- 🧩 **Zero client code changes** between Live and Replay—clients always “read files.”
-- ⚙️ **Tiny footprint**: Boost.Asio/Beast + nlohmann/json; no heavy deps.
+- 🚦 **Two explicit sinks** keep live and replay data flows separate and auditable.
+- 🔁 **Playback utility** replays dumpbox sessions by re-posting them to the marshal.
+- 🔓 **HDF5 SWMR streaming** (`POST /v1/ismrmrd/frame`) lets clients open growing MRD
+  files safely while the marshal appends new frames.
+- 🧩 **Clients stay simple:** they only ever read MRD files on disk.
+- ⚙️ **No heavy dependencies:** Boost.Asio/Beast and nlohmann/json do the heavy lifting.
+
+---
+
+## First-time setup (10 minutes)
+
+1. **Install build tools** (Ubuntu/Debian):
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y build-essential cmake ninja-build pkg-config libboost-system-dev
+   ```
+   Docker images built from `docker/Dockerfile` already contain the runtime pieces
+   required for HDF5 SWMR.
+2. **Configure + build** the binaries:
+   ```bash
+   mkdir -p build
+   cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF
+   cmake --build build -j"$(nproc)"
+   ```
+3. **Pick a sink:**
+   - Live MRD files: `./build/marshal --http 0.0.0.0:8080 --ws 0.0.0.0:8090 --data ./data --sink mrd`.
+   - Record-only dumpbox: `./build/marshal --http ... --sink dumpbox --dumpbox-root ./data/dumpbox`.
+4. **Ingest data:**
+   - Upload MRD files via `POST /v1/mrd/ingest` (curl examples below).
+   - Append SWMR frames via `POST /v1/ismrmrd/frame` with ISMRMRD image
+     messages to stream voxels into a growing dataset that readers can follow in
+     near real time.
+5. **Inspect outputs:** MRD sink writes to `./data/mrd`; dumpbox sink writes to
+   `./data/dumpbox/<session>/files`. Metadata is mirrored in `index.jsonl` and
+   `latest.json` for simple polling clients.
+
+The step-by-step runbooks in [`README_MODE_A.md`](README_MODE_A.md) and
+[`README_MODE_B.md`](README_MODE_B.md) expand on these steps with copy/paste-able
+commands, cleanup instructions, and verification tips.
 
 ---
 
@@ -47,28 +82,18 @@ This keeps the data sink unambiguous: **one or the other**.
 
 ## Build
 
-### Prereqs (Ubuntu/Debian)
-```bash
-sudo apt-get update
-sudo apt-get install -y       build-essential cmake ninja-build pkg-config       libboost-system-dev
-```
+### Binaries produced
 
-### Compile
-```bash
-mkdir -p build
-cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF
-cmake --build build -j"$(nproc)"
-```
-
-**Binaries**
-- `build/marshal` — server (HTTP/WS)
-- `build/playback` — **HTTP-only** playback (replays dumpbox sessions)
+- `build/marshal` — HTTP/WebSocket server.
+- `build/playback` — HTTP-only session replayer (feeds dumpbox sessions back to the marshal).
+- `build/viz_client` — simple HDF5 SWMR-aware visualization client.
+- `build/mk_mrd` — utility that creates valid placeholder MRD files for smoke tests.
 
 ---
 
 ## Quick start
 
-> Full, copy-pasteable runbooks are in `README_MODE_A.md` (Live) and `README_MODE_B.md` (Record→Replay).  
+> Full, copy-pasteable runbooks are in `README_MODE_A.md` (Live) and `README_MODE_B.md` (Record→Replay).
 > Below are minimal one-liners.
 
 ### Live (Mode A) — scanner → MRD → clients
@@ -91,17 +116,23 @@ tail -n 5 ./data/mrd/index.jsonl || true
 cat ./data/mrd/latest.json
 ```
 
----
+#### Stream frames with SWMR
 
-## Developer note: MRD ingestion helper
+The marshal accepts ISMRMRD Image messages. Each POST body is an
+`ISMRMRD::ImageHeader` immediately followed by the raw voxel payload. See
+[`docs/API_REFERENCE.md`](docs/API_REFERENCE.md#post-v1ismrmrdframe) for the
+exact layout and a Python packing snippet. Once you have a binary message:
 
-Both the HTTP (`POST /v1/mrd/ingest`) and WebSocket binary ingest paths share
-`include/mrd_io.hpp`.  The helper writes the payload to a temporary file,
-`fsync`s it, and atomically renames it into place before appending to
-`index.jsonl` and rewriting `latest.json`.  It then emits the corresponding
-metadata JSON over the WebSocket fan-out.  Reusing this helper keeps the HTTP
-and WebSocket behaviours identical and guarantees clients only ever see fully
-flushed MRD artifacts.
+```bash
+curl -fsS \
+  -H 'Content-Type: application/octet-stream' \
+  -H 'X-MRD-Stream: demo_stream' \
+  --data-binary @image_message.bin \
+  http://localhost:8080/v1/ismrmrd/frame | jq
+
+# Follow the growing dataset (requires HDF5 runtime on the system)
+./build/viz_client --ws ws://localhost:8090/ws --data ./data/mrd
+```
 
 ### Record→Replay (Mode B)
 ```bash
@@ -135,13 +166,29 @@ cat ./data/mrd/latest.json
 
 ---
 
+## Developer note: MRD ingestion helper
+
+Both the HTTP (`POST /v1/mrd/ingest`) and WebSocket binary ingest paths share
+`include/mrd_io.hpp`.  The helper writes the payload to a temporary file,
+`fsync`s it, and atomically renames it into place before appending to
+`index.jsonl` and rewriting `latest.json`.  It then emits the corresponding
+metadata JSON over the WebSocket fan-out.  Reusing this helper keeps the HTTP
+and WebSocket behaviours identical and guarantees clients only ever see fully
+flushed MRD artifacts.
+
 ## HTTP API
 
-- **`POST /v1/mrd/ingest`** — Body: MRD bytes (`application/octet-stream`)  
-  - **MRD mode:** writes to `/data/mrd`, updates global `index.jsonl`/`latest.json`.  
+- **`POST /v1/mrd/ingest`** — Body: MRD bytes (`application/octet-stream`)
+  - **MRD mode:** writes to `/data/mrd`, updates global `index.jsonl`/`latest.json`.
   - **Dumpbox mode:** writes to session under `/data/dumpbox/<SESSION>`, updates session `index.jsonl`/`latest.json`.
+- **`POST /v1/ismrmrd/frame`** — Body: ISMRMRD Image header + voxels
+  - `X-MRD-Stream`: logical identifier; the marshal will keep a matching `.mrd` file open
+  - Appends into `/dataset/images/data` using HDF5 SWMR so readers can open the file while it grows
 - **`GET /health`** — returns `ok`.
 - **(If present) `GET /v1/mrd/since?ts=...&limit=...`** — convenience reader over `index.jsonl`.
+
+See [`docs/API_REFERENCE.md`](docs/API_REFERENCE.md) for details, payload examples,
+and error semantics aimed at new integrators.
 
 ---
 

--- a/README_MODE_A.md
+++ b/README_MODE_A.md
@@ -1,21 +1,39 @@
-set -euo pipefail
+# Mode A — Live MRD sink runbook
 
-# 0) Build
+This guide walks a new operator through building the marshal, starting it in
+live MRD mode, uploading example MRD files, and streaming SWMR frames that
+clients can visualize immediately.
+
+> 💡 Tip: You can copy/paste the commands in each block directly into a shell.
+> Run them from the repository root unless noted otherwise.
+
+---
+
+## 0. Build the project
+
+```bash
 mkdir -p build
 cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF
 cmake --build build -j"$(nproc)"
+```
 
-# 1) Clean data + make folders (safe for mounts)
+## 1. Reset the data directory (safe for bind mounts)
+
+```bash
 mkdir -p ./data
 find ./data -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 mkdir -p ./data/mrd
+```
 
-# 2) Stop any old server
+## 2. Stop any previous marshal instance
+
+```bash
 pkill -f "/build/marshal" >/dev/null 2>&1 || true
+```
 
-# 3) Start marshal in MRD sink (live mode)
-#    - MRD files land in ./data/mrd
-#    - HTTP on :8080, WebSocket fan-out on :8090
+## 3. Start the marshal in MRD mode (live)
+
+```bash
 ./build/marshal \
   --http 0.0.0.0:8080 \
   --ws   0.0.0.0:8090 \
@@ -25,33 +43,68 @@ pkill -f "/build/marshal" >/dev/null 2>&1 || true
 
 MARSHAL_PID=$!
 sleep 1
+```
 
-# 4) Health check
+## 4. Verify the service is healthy
+
+```bash
 curl -fsS http://localhost:8080/health | tee /dev/stderr
+```
 
-# 5) Produce two VALID MRD files and ingest them via HTTP (unchanged)
+## 5. Generate valid MRD samples and ingest them
+
+```bash
 ./build/mk_mrd ./data/mrd/sample_live_1.h5
 ./build/mk_mrd ./data/mrd/sample_live_2.h5
+
 curl -fsS -H "Content-Type: application/octet-stream" \
   --data-binary @./data/mrd/sample_live_1.h5 \
   http://localhost:8080/v1/mrd/ingest | tee /dev/stderr
+
 curl -fsS -H "Content-Type: application/octet-stream" \
   --data-binary @./data/mrd/sample_live_2.h5 \
   http://localhost:8080/v1/mrd/ingest | tee /dev/stderr
+```
 
-# 6) (Optional) WebSocket ingest smoke test (requires websocat)
-# Send the MRD payload as a single binary frame; the server will write a new file
-# and broadcast the ingest metadata back to any subscribers.
+## 6. (Optional) Append streaming frames via SWMR
+
+Capture or synthesize an ISMRMRD Image message (header + voxels) and save it as
+`image_message.bin`, then stream it into a live MRD file identified by
+`live_demo`. See [`docs/API_REFERENCE.md`](docs/API_REFERENCE.md#post-v1ismrmrdframe)
+for a Python helper snippet:
+
+```bash
+curl -fsS \
+  -H 'Content-Type: application/octet-stream' \
+  -H 'X-MRD-Stream: live_demo' \
+  --data-binary @image_message.bin \
+  http://localhost:8080/v1/ismrmrd/frame | tee /dev/stderr
+```
+
+## 7. (Optional) Smoke-test WebSocket ingestion
+
+If you have [`websocat`](https://github.com/vi/websocat) installed, you can send
+an MRD payload over the `/ws` endpoint and watch the marshal broadcast the
+resulting metadata:
+
+```bash
 if command -v websocat >/dev/null; then
   websocat -b ws://127.0.0.1:8090/ < ./data/mrd/sample_live_1.h5 || true
 fi
+```
 
-# 7) Verify outputs for clients (tolerant)
+## 8. Inspect outputs like a client would
+
+```bash
 echo "== MRD files =="; ls -l ./data/mrd || true
 echo "== latest.json =="; [ -f ./data/mrd/latest.json ] && cat ./data/mrd/latest.json || echo "(none)"
 echo "== index.jsonl (MRD) tail =="; [ -f ./data/mrd/index.jsonl ] && tail -n 5 ./data/mrd/index.jsonl || echo "(none)"
+```
 
-# 8) Stop marshal
+## 9. Cleanly stop the marshal
+
+```bash
 kill "$MARSHAL_PID"
 wait "$MARSHAL_PID" 2>/dev/null || true
 echo "Live mode done."
+```

--- a/README_MODE_B.md
+++ b/README_MODE_B.md
@@ -1,23 +1,41 @@
-set -euo pipefail
+# Mode B — Record then replay runbook
 
-# 0) Build
+Follow this walkthrough to capture MRD files into a dumpbox session, then replay
+that session back through the marshal so clients receive fresh MRDs exactly as if
+they were produced live.
+
+> 📦 The commands assume you are in the repository root. Adjust paths if you use
+> a different data directory.
+
+---
+
+## Phase 0 — Build once
+
+```bash
 mkdir -p build
 cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=OFF
 cmake --build build -j"$(nproc)"
+```
 
-# 1) Clean data + make folders (safe for mounts)
+## Phase 1 — Record into a dumpbox session
+
+### 1. Prepare directories
+
+```bash
 mkdir -p ./data
 find ./data -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 mkdir -p ./data/mrd ./data/dumpbox
+```
 
-# -------------------------------
-# PHASE 1 — RECORD to dumpbox
-# -------------------------------
+### 2. Ensure no previous marshal instance is running
 
-# 2) Stop any old server
+```bash
 pkill -f "/build/marshal" >/dev/null 2>&1 || true
+```
 
-# 3) Start marshal in DUMPBOX sink (session auto-named)
+### 3. Start the marshal in dumpbox mode
+
+```bash
 ./build/marshal \
   --http 0.0.0.0:8080 \
   --ws   0.0.0.0:8090 \
@@ -28,43 +46,77 @@ pkill -f "/build/marshal" >/dev/null 2>&1 || true
 
 MARSHAL_REC_PID=$!
 sleep 1
+```
 
-# 4) Health check
+### 4. Health check
+
+```bash
 curl -fsS http://localhost:8080/health | tee /dev/stderr
+```
 
-# 5) Produce two VALID MRD files and ingest them via HTTP
+### 5. Upload MRD samples (and optional SWMR frames)
+
+```bash
 ./build/mk_mrd ./data/mrd/tmp_record_1.h5
 ./build/mk_mrd ./data/mrd/tmp_record_2.h5
+
 curl -fsS -H "Content-Type: application/octet-stream" \
   --data-binary @./data/mrd/tmp_record_1.h5 \
   http://localhost:8080/v1/mrd/ingest | tee /dev/stderr
+
 curl -fsS -H "Content-Type: application/octet-stream" \
   --data-binary @./data/mrd/tmp_record_2.h5 \
   http://localhost:8080/v1/mrd/ingest | tee /dev/stderr
+```
 
-# 6) Locate the newest dumpbox session (contains files/ + metadata)
+(Optional) append SWMR frames to the active session by capturing an ISMRMRD
+Image message (header + voxels) and saving it as `dumpbox_image_message.bin`.
+Refer to [`docs/API_REFERENCE.md`](docs/API_REFERENCE.md#post-v1ismrmrdframe)
+for a packing helper:
+
+```bash
+curl -fsS \
+  -H 'Content-Type: application/octet-stream' \
+  -H 'X-MRD-Stream: dumpbox_demo' \
+  --data-binary @dumpbox_image_message.bin \
+  http://localhost:8080/v1/ismrmrd/frame | tee /dev/stderr
+```
+
+### 6. Locate the newest session
+
+The loop waits for MRD files to arrive before proceeding.
+
+```bash
 SESSION_DIR=""
 for _ in $(seq 1 25); do
   SESSION_DIR=$(ls -dt ./data/dumpbox/*/ 2>/dev/null | head -n1 || true)
   [ -n "${SESSION_DIR}" ] && ls "${SESSION_DIR}"/files/*.mrd >/dev/null 2>&1 && break
   sleep 0.2
 done
+
 [ -n "${SESSION_DIR}" ] || { echo "no dumpbox session found"; exit 1; }
 echo "SESSION_DIR=${SESSION_DIR}"
+```
 
-# (Optional) Inspect recorded outputs
+Inspect what was recorded:
+
+```bash
 echo "== Session files =="; find "$SESSION_DIR" -maxdepth 2 -type f -print | sed 's|^|  |'
 echo "== index.jsonl tail =="; tail -n 5 "$SESSION_DIR/index.jsonl" || true
+```
 
-# 7) Stop marshal (record phase done)
+### 7. Stop the marshal (recording complete)
+
+```bash
 kill "$MARSHAL_REC_PID"
 wait "$MARSHAL_REC_PID" 2>/dev/null || true
+```
 
-# -------------------------------
-# PHASE 2 — REPLAY as live
-# -------------------------------
+## Phase 2 — Replay the session as live MRDs
 
-# 8) Start marshal back in MRD sink
+### 8. Start the marshal back in MRD mode
+
+```bash
 ./build/marshal \
   --http 0.0.0.0:8080 \
   --ws   0.0.0.0:8090 \
@@ -74,19 +126,32 @@ wait "$MARSHAL_REC_PID" 2>/dev/null || true
 
 MARSHAL_REP_PID=$!
 sleep 1
+```
 
-# 9) Health check
+### 9. Confirm the service is ready
+
+```bash
 curl -fsS http://localhost:8080/health | tee /dev/stderr
+```
 
-# 10) Replay the recorded session via HTTP
+### 10. Replay the recorded session
+
+```bash
 ./build/playback --http http://localhost:8080 --data "$SESSION_DIR" --speed 1.0
+```
 
-# 11) Verify MRD outputs
+### 11. Verify replay outputs
+
+```bash
 echo "== MRD files (replayed) =="; ls -l ./data/mrd || true
 echo "== latest.json (MRD) =="; [ -f ./data/mrd/latest.json ] && cat ./data/mrd/latest.json || echo "(none)"
 echo "== index.jsonl tail (MRD) =="; [ -f ./data/mrd/index.jsonl ] && tail -n 5 ./data/mrd/index.jsonl || echo "(none)"
+```
 
-# 12) Stop marshal
+### 12. Shut everything down
+
+```bash
 kill "$MARSHAL_REP_PID"
 wait "$MARSHAL_REP_PID" 2>/dev/null || true
 echo "Record→Replay mode done."
+```

--- a/clients/viz_client/viz_client_main.cpp
+++ b/clients/viz_client/viz_client_main.cpp
@@ -7,6 +7,8 @@
 #include <boost/beast/websocket.hpp>
 #include <nlohmann/json.hpp>
 #include <boost/beast/core/buffers_to_string.hpp>
+#include <hdf5.h>
+#include <vector>
 
 using json = nlohmann::json;
 namespace fs = std::filesystem;
@@ -20,6 +22,58 @@ static std::time_t file_time_to_time_t(std::filesystem::file_time_type t)
     const auto sctp = time_point_cast<system_clock::duration>(
         t - std::filesystem::file_time_type::clock::now() + system_clock::now());
     return system_clock::to_time_t(sctp);
+}
+
+static void inspect_swmr_file(const std::string &path)
+{
+    if (path.empty())
+        return;
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    if (fapl < 0)
+        return;
+    H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI);
+    hid_t file = H5Fopen(path.c_str(), H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+    H5Pclose(fapl);
+    if (file < 0)
+    {
+        std::cerr << "viz: unable to open SWMR file " << path << "\n";
+        return;
+    }
+    hid_t dset = H5Dopen2(file, "/dataset/images/data", H5P_DEFAULT);
+    if (dset < 0)
+    {
+        std::cerr << "viz: /dataset/images/data dataset missing in " << path << "\n";
+        H5Fclose(file);
+        return;
+    }
+    if (H5Drefresh(dset) < 0)
+    {
+        std::cerr << "viz: H5Drefresh failed for " << path << "\n";
+    }
+    hid_t space = H5Dget_space(dset);
+    if (space < 0)
+    {
+        std::cerr << "viz: cannot read dataset space" << std::endl;
+        H5Dclose(dset);
+        H5Fclose(file);
+        return;
+    }
+    int rank = H5Sget_simple_extent_ndims(space);
+    std::vector<hsize_t> dims(rank, 0);
+    if (rank > 0)
+        H5Sget_simple_extent_dims(space, dims.data(), nullptr);
+    H5Sclose(space);
+    H5Dclose(dset);
+    H5Fclose(file);
+
+    if (dims.size() == 5)
+    {
+        std::cout << "viz swmr: frames=" << dims[0]
+                  << " channels=" << dims[1]
+                  << " shape=" << dims[4] << "x" << dims[3] << "x" << dims[2]
+                  << "\n";
+    }
 }
 
 int main(int argc, char **argv)
@@ -50,13 +104,23 @@ int main(int argc, char **argv)
         std::time_t last = 0;
         while (true) {
             try {
-                if (fs::exists(latest)) {
+                    if (fs::exists(latest)) {
                    // auto wt = decltype(fs::last_write_time(latest))::clock::to_time_t(fs::last_write_time(latest));
                    auto wt = file_time_to_time_t(fs::last_write_time(latest));
                    if (wt != last) {
                         std::ifstream lf(latest);
                         json lj; lf >> lj;
                         std::cout << "viz latest=" << lj.dump() << "\n";
+                        if (lj.contains("frame_index") && lj.contains("path"))
+                        {
+                            try
+                            {
+                                inspect_swmr_file(lj["path"].get<std::string>());
+                            }
+                            catch (...)
+                            {
+                            }
+                        }
                         last = wt;
                     }
                 }
@@ -97,7 +161,19 @@ int main(int argc, char **argv)
             buf.consume(buf.size());
             auto j = json::parse(s, nullptr, false);
             if (j.is_object())
+            {
                 std::cout << "viz ws: " << j.dump() << "\n";
+                if (j.contains("frame_index") && j.contains("path"))
+                {
+                    try
+                    {
+                        inspect_swmr_file(j["path"].get<std::string>());
+                    }
+                    catch (...)
+                    {
+                    }
+                }
+            }
         }
     }
     catch (const std::exception &e)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -107,6 +107,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   lld \
   libpugixml1v5 \
   libhdf5-103-1 \
+  libhdf5-hl-200 \
   libboost-system1.83.0 libboost-filesystem1.83.0 libboost-thread1.83.0 libboost-program-options1.83.0 \
   util-linux \
   bsdmainutils \

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,194 @@
+# API reference
+
+This document introduces the marshal's external interfaces from the perspective
+of an integrator seeing the project for the first time. All examples use
+`http://localhost:8080` as the base URL; substitute your deployment address as
+needed.
+
+The marshal exposes a small HTTP API for ingesting MRD data, plus an optional
+WebSocket broadcast channel for metadata fan-out.
+
+---
+
+## Conventions
+
+- **Content types:** binary MRD payloads use `application/octet-stream`. JSON
+  responses are encoded as UTF-8.
+- **Timestamps:** metadata files and WebSocket messages use ISO-8601 timestamps
+  with millisecond precision in UTC.
+- **Authentication:** not provided by the marshal. Run it behind your own
+  ingress/proxy if needed.
+- **Error format:** errors return an HTTP status code (4xx or 5xx) and a JSON
+  body of the form `{ "error": "human readable" }`.
+
+---
+
+## `POST /v1/mrd/ingest`
+
+Upload a complete ISMRMRD (`.mrd`) file. The marshal writes it to the current
+sink (live MRD or dumpbox session) and updates the corresponding metadata files.
+
+### Request
+
+- **Headers**
+  - `Content-Type: application/octet-stream`
+- **Body**: raw MRD file bytes.
+
+### Response
+
+- **Status 200** on success with JSON metadata describing where the file was
+  stored. Example (live MRD sink):
+
+  ```json
+  {
+    "path": "2025-09-20T01:23:45.123Z_000001.mrd",
+    "size": 16384,
+    "timestamp": "2025-09-20T01:23:45.123Z"
+  }
+  ```
+- **Status 400** if the body is empty or the file cannot be written.
+- **Status 500** for unexpected errors.
+
+### Side effects
+
+- Writes the binary file to either `data/mrd/` (live mode) or
+  `data/dumpbox/<session>/files/` (record mode).
+- Appends a JSON line to the appropriate `index.jsonl`.
+- Rewrites the relevant `latest.json` with the most recent metadata.
+- Broadcasts the metadata JSON over the WebSocket channel (if any clients are
+  connected).
+
+---
+
+## `POST /v1/ismrmrd/frame`
+
+Append an ISMRMRD Image message directly into a growing HDF5 dataset while the
+file remains open in Single-Writer-Multiple-Reader (SWMR) mode. Each logical
+stream maps to one `.mrd` file under the current sink.
+
+### Required headers
+
+| Header | Description |
+| ------ | ----------- |
+| `X-MRD-Stream` | Logical stream identifier (ASCII). Determines the `.mrd` filename. |
+
+### Body
+
+Binary concatenation of:
+
+1. `ISMRMRD::ImageHeader` (as defined in `ismrmrd/ismrmrd.h`).
+2. Raw voxel payload whose size matches `matrix_size × channels × datatype`.
+
+#### Packing example (Python)
+
+```bash
+pip install ismrmrd numpy  # once per environment
+python - <<'PY'
+import numpy as np
+import ismrmrd
+
+# Create a 4x3 single-channel float32 image with obvious values
+data = np.arange(12, dtype=np.float32).reshape(3, 4)
+img = ismrmrd.Image.from_array(data)
+img.head.channels = 1
+img.head.data_type = ismrmrd.DATATYPE_FLOAT
+
+with open('image_message.bin', 'wb') as f:
+    f.write(img.getHead().tobytes())
+    f.write(img.data.tobytes())
+PY
+```
+
+### Response
+
+JSON describing the stream after the append:
+
+```json
+{
+  "stream": "demo_stream",
+  "frames_written": 3,
+  "frame_shape": [4, 3],
+  "channels": 2,
+  "datatype": "float32",
+  "path": "demo_stream.mrd"
+}
+```
+
+- **Status 200** on success.
+- **Status 400** if headers are missing/invalid or the payload length does not
+  match the ISMRMRD header metadata.
+- **Status 500** if the marshal fails to write or flush the SWMR dataset.
+
+### Reader expectations
+
+- Readers open the `.mrd` file using `H5F_ACC_SWMR_READ`. The marshal flushes
+  dataset + file metadata after every append, so newly written frames become
+  visible quickly.
+- Image voxels live in `/dataset/images/data` with shape
+  `[frames, channels, z, y, x]`.
+- A minimal ISMRMRD XML header is stored at `/dataset/header`.
+
+---
+
+## `GET /health`
+
+Simple readiness probe. Returns HTTP 200 with body `ok` when the marshal is
+running.
+
+---
+
+## `GET /v1/mrd/since`
+
+> This endpoint is optional and may be disabled in some builds.
+
+Page through ingest metadata without touching the filesystem directly.
+
+### Query parameters
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `ts` | no | ISO-8601 timestamp to start from (exclusive). Defaults to the beginning of the log. |
+| `limit` | no | Maximum number of records to return. Defaults to 50. |
+
+### Response
+
+JSON array of metadata objects in chronological order.
+
+---
+
+## WebSocket `/ws`
+
+The marshal accepts binary MRD payloads over WebSocket (mirroring the HTTP
+`/v1/mrd/ingest` endpoint) and broadcasts JSON metadata to all connected clients
+whenever an ingest completes.
+
+- **Binary frames** are treated exactly like HTTP uploads.
+- **Text frames** are ignored.
+- **Broadcast payload** matches the JSON returned by the ingest endpoints.
+
+This channel is useful for visualization clients that want push notifications
+when new MRD files or SWMR frames arrive.
+
+---
+
+## Filesystem contract
+
+Regardless of mode, clients can rely on the following metadata artefacts:
+
+- `index.jsonl` — newline-delimited metadata describing all ingested MRDs.
+- `latest.json` — JSON document mirroring the most recent ingest.
+
+Live mode keeps these files in `data/mrd/`; record mode keeps them within the
+active dumpbox session directory.
+
+---
+
+## Related documentation
+
+- [`README.md`](../README.md) — conceptual overview and quick start.
+- [`README_MODE_A.md`](../README_MODE_A.md) — full live-mode runbook.
+- [`README_MODE_B.md`](../README_MODE_B.md) — full record→replay runbook.
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — deeper dive into internal
+  components.
+- [`docs/USAGE_WITH_CLIENTS.md`](USAGE_WITH_CLIENTS.md) — walkthroughs that pair
+  the marshal with bundled sample clients.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,51 @@
+# Architecture Overview
+
+CWRU Data Marshal is a single-process hub that accepts reconstructed MRI data
+and pose updates over HTTP/WebSocket, persists them on disk, and fans metadata
+out to connected clients. The core components are:
+
+- **HTTP server (`HttpServer`)** — Handles REST endpoints for MRD ingest,
+  SWMR frame streaming, pose updates, and metadata queries.
+- **WebSocket server (`WsServer`)** — Broadcasts ingest and pose events to
+  subscribed clients.
+- **Storage helpers (`mrd_io.hpp`)** — Provide atomic file writes, index and
+  metadata maintenance, and sink selection logic for MRD vs. dumpbox modes.
+- **SWMR manager (`SwmrManager`)** — Manages extendible HDF5 datasets that stay
+  open while new frames arrive.
+
+## Request flow
+
+1. **Ingesting full MRDs** (`POST /v1/mrd/ingest`)
+   - The HTTP handler forwards the payload to `mrd::ingest_payload()` which
+     writes the file atomically into either `/data/mrd` (live) or the active
+     dumpbox session, updates `index.jsonl`/`latest.json`, and emits a WebSocket
+     notification.
+2. **Streaming frames** (`POST /v1/ismrmrd/frame`)
+   - The handler parses the ISMRMRD image header from the request body, derives
+     geometry + datatype, and asks `SwmrManager` to append the payload into the
+     scan's MRD. `SwmrManager` ensures one open file per stream and uses
+     `SwmrFile` to extend `/dataset/images/data` via HDF5 SWMR APIs.
+   - Each append logs into the same index files as full MRD ingests so clients
+     have a unified view of activity.
+3. **Poses and telemetry**
+   - Pose updates update the in-memory `PoseStore` and immediately broadcast.
+
+## SWMR file layout
+
+Each SWMR stream creates a file named
+`<timestamp>_<sanitized-stream>.mrd` inside the active sink. The file contains
+standard ISMRMRD structure:
+
+- `/dataset/header` — scalar string dataset with a minimal XML header tailored
+  to the stream geometry.
+- `/dataset/images/data` — extendible dataset with shape
+  `[frames, channels, z, y, x]` storing voxel payloads.
+
+Writers call `H5Fstart_swmr_write` once at creation and `H5Dflush`/`H5Fflush`
+after each frame so SWMR readers can see consistent snapshots without waiting
+for the file to close.
+
+`viz_client` demonstrates the reader side by opening the MRD file with
+`H5F_ACC_SWMR_READ` whenever `index.jsonl` advertises a new frame. Because the
+same index files record both full ingests and SWMR frames, existing tailing
+clients continue to work.

--- a/docs/USAGE_WITH_CLIENTS.md
+++ b/docs/USAGE_WITH_CLIENTS.md
@@ -116,6 +116,23 @@ The WebSocket fan-out will emit pose notifications that `viz_client` will show
 immediately. You can re-run `fk_client` any time to emulate the scanner pose
 stream.
 
+### 5b. Stream reconstructed frames via SWMR
+
+The marshal can now append ISMRMRD Image messages into a live MRD file while
+`viz_client` observes the growth. Once you have a packed message saved as
+`viz_image_message.bin` (see
+[`docs/API_REFERENCE.md`](API_REFERENCE.md#post-v1ismrmrdframe) for a helper):
+
+```bash
+curl -fsS \
+  -H 'Content-Type: application/octet-stream' \
+  -H 'X-MRD-Stream: viz_demo' \
+  --data-binary @viz_image_message.bin \
+  http://localhost:8080/v1/ismrmrd/frame | tee /dev/stderr
+```
+
+`viz_client` will print the new frame count immediately thanks to HDF5 SWMR.
+
 ### 6. Inspect live-mode outputs
 
 ```bash

--- a/include/mrd_io.hpp
+++ b/include/mrd_io.hpp
@@ -68,6 +68,41 @@ inline void ensure_dir(const std::filesystem::path &p)
     }
 }
 
+struct SinkPaths
+{
+    std::filesystem::path sink_root;
+    std::filesystem::path index_root;
+};
+
+inline SinkPaths resolve_sink_paths(MarshalState &state)
+{
+    namespace fs = std::filesystem;
+    SinkPaths paths;
+
+    fs::path mrd_root = fs::path(state.data_dir) / "mrd";
+    ensure_dir(mrd_root);
+
+    if (state.sink_mode == SinkMode::MRD)
+    {
+        paths.sink_root = mrd_root;
+        paths.index_root = mrd_root;
+    }
+    else
+    {
+        std::string session = state.dumpbox_session.empty() ? iso8601_now_ms() : state.dumpbox_session;
+        fs::path session_dir = fs::path(state.dumpbox_root) / session;
+        paths.index_root = session_dir;
+        paths.sink_root = session_dir / "files";
+        std::error_code ec_mk;
+        std::filesystem::create_directories(paths.sink_root, ec_mk);
+        if (ec_mk)
+            throw std::runtime_error("ensure dumpbox sink failed: " + ec_mk.message());
+        state.dumpbox_session = session;
+    }
+
+    return paths;
+}
+
 inline void write_atomic(const std::filesystem::path &dst, const void *data, size_t n)
 {
     namespace fs = std::filesystem;
@@ -163,34 +198,16 @@ inline nlohmann::json ingest_payload(MarshalState &state,
 {
     namespace fs = std::filesystem;
 
-    fs::path mrd_root = fs::path(state.data_dir) / "mrd";
-    ensure_dir(mrd_root);
-
     const std::string ts = iso8601_now_ms();
     const uint64_t seq = ingest_sequence().fetch_add(1);
 
     std::ostringstream name;
     name << ts << '_' << std::setw(6) << std::setfill('0') << seq << ".mrd";
 
-    fs::path sink_root;
-    fs::path index_root;
-    if (state.sink_mode == SinkMode::MRD)
-    {
-        sink_root = mrd_root;
-        index_root = mrd_root;
-    }
-    else
-    {
-        std::string session = state.dumpbox_session.empty() ? iso8601_now_ms() : state.dumpbox_session;
-        fs::path session_dir = fs::path(state.dumpbox_root) / session;
-        index_root = session_dir;
-        sink_root = session_dir / "files";
-        std::error_code ec_mk;
-        std::filesystem::create_directories(sink_root, ec_mk);
-        if (ec_mk)
-            throw std::runtime_error("ensure dumpbox sink failed: " + ec_mk.message());
-        state.dumpbox_session = session;
-    }
+    SinkPaths paths = resolve_sink_paths(state);
+
+    fs::path sink_root = paths.sink_root;
+    fs::path index_root = paths.index_root;
 
     fs::path out_path = sink_root / name.str();
     write_atomic(out_path, data, size);

--- a/include/swmr_writer.hpp
+++ b/include/swmr_writer.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <hdf5.h>
+
+#include <nlohmann/json.hpp>
+
+#include "marshal_state.hpp"
+
+namespace mrd
+{
+
+enum class ElementType
+{
+    Float32,
+    UInt16
+};
+
+struct StreamDimensions
+{
+    std::array<hsize_t, 3> spatial{}; // {x, y, z}
+    hsize_t channels{1};
+};
+
+struct SwmrFrameResult
+{
+    std::filesystem::path file_path;
+    std::string stream_id;
+    std::string timestamp;
+    uint64_t frame_index{0};
+    size_t bytes{0};
+    ElementType element_type{ElementType::Float32};
+    StreamDimensions dims;
+};
+
+class SwmrFile
+{
+  public:
+    SwmrFile(const std::filesystem::path &path,
+             const std::string &stream_id,
+             ElementType type,
+             const StreamDimensions &dims,
+             std::string header_xml);
+    ~SwmrFile();
+
+    SwmrFile(const SwmrFile &) = delete;
+    SwmrFile &operator=(const SwmrFile &) = delete;
+
+    SwmrFrameResult append_frame(const void *data, size_t bytes);
+
+    const std::filesystem::path &path() const noexcept { return path_; }
+    ElementType element_type() const noexcept { return type_; }
+    const StreamDimensions &dims() const noexcept { return dims_; }
+    uint64_t frame_count() const noexcept { return frames_; }
+    size_t frame_bytes() const noexcept { return frame_bytes_; }
+
+  private:
+    std::filesystem::path path_;
+    std::string stream_id_;
+    ElementType type_;
+    StreamDimensions dims_;
+    std::string header_xml_;
+    hid_t file_{-1};
+    hid_t dataset_{-1};
+    size_t frame_bytes_{0};
+    uint64_t frames_{0};
+    std::mutex write_mutex_;
+
+    void open();
+    void close();
+};
+
+class SwmrManager
+{
+  public:
+    explicit SwmrManager(MarshalState &state);
+
+    SwmrManager(const SwmrManager &) = delete;
+    SwmrManager &operator=(const SwmrManager &) = delete;
+
+    SwmrFrameResult append_frame(const std::string &stream_id,
+                                 const StreamDimensions &dims,
+                                 ElementType type,
+                                 std::string_view header_xml,
+                                 const void *data,
+                                 size_t bytes);
+
+  private:
+    struct StreamState
+    {
+        std::unique_ptr<SwmrFile> file;
+        std::mutex mutex;
+        StreamDimensions dims;
+        ElementType type{ElementType::Float32};
+        std::string header_xml;
+    };
+
+    MarshalState &state_;
+    std::mutex map_mutex_;
+    std::unordered_map<std::string, std::shared_ptr<StreamState>> streams_;
+
+    std::shared_ptr<StreamState> ensure_stream(const std::string &stream_id,
+                                               const StreamDimensions &dims,
+                                               ElementType type,
+                                               const std::filesystem::path &sink_root,
+                                               std::string_view header_xml);
+    static std::string sanitize_stream(const std::string &stream_id);
+    static std::string element_type_string(ElementType t);
+    nlohmann::json make_entry_json(const SwmrFrameResult &result) const;
+};
+
+ElementType parse_element_type(const std::string &value);
+std::string element_type_to_string(ElementType type);
+size_t element_type_bytes(ElementType type);
+ElementType element_type_from_ismrmrd(uint16_t data_type);
+std::string default_ismrmrd_header(const StreamDimensions &dims, ElementType type, std::string_view stream_id);
+
+} // namespace mrd

--- a/src/marshal_http.hpp
+++ b/src/marshal_http.hpp
@@ -21,16 +21,21 @@
 #include <nlohmann/json.hpp>
 #include "mrd_io.hpp"
 
+#include <array>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
-#include <memory>
-#include <string>
-#include <chrono>
 #include <iomanip>
+#include <memory>
 #include <sstream>
+#include <string>
+#include <vector>
+#include <cctype>
 
 #include "marshal_state.hpp"
 #include "common/pose.hpp" // Pose, PoseStore, pose_to_json
+#include "swmr_writer.hpp"
+#include <ismrmrd/ismrmrd.h>
 
 namespace http = boost::beast::http;
 namespace fs = std::filesystem;
@@ -266,6 +271,74 @@ private:
                                  .dump();
                 res.prepare_payload();
                 return respond(std::move(res));
+            }
+
+            // POST /v1/ismrmrd/frame  (append ISMRMRD Image to SWMR dataset)
+            if (req.method() == http::verb::post && req.target() == "/v1/ismrmrd/frame")
+            {
+                using namespace std::string_literals;
+                try
+                {
+                    if (!state.swmr)
+                        throw std::runtime_error("SWMR manager unavailable");
+                    auto stream_header = std::string(req["X-MRD-Stream"]);
+                    if (stream_header.empty())
+                        throw std::runtime_error("missing X-MRD-Stream header");
+                    const std::string &body = req.body();
+                    if (body.empty())
+                        throw std::runtime_error("empty body");
+                    if (body.size() < sizeof(ISMRMRD::ImageHeader))
+                        throw std::runtime_error("body too small for ISMRMRD ImageHeader");
+
+                    const auto *img_header = reinterpret_cast<const ISMRMRD::ImageHeader *>(body.data());
+                    mrd::StreamDimensions dims;
+                    dims.spatial = {static_cast<hsize_t>(img_header->matrix_size[0]),
+                                    static_cast<hsize_t>(img_header->matrix_size[1]),
+                                    static_cast<hsize_t>(img_header->matrix_size[2])};
+                    dims.channels = img_header->channels ? static_cast<hsize_t>(img_header->channels) : 1;
+                    if (dims.spatial[0] == 0 || dims.spatial[1] == 0)
+                        throw std::runtime_error("invalid matrix size in header");
+
+                    auto element_type = mrd::element_type_from_ismrmrd(img_header->data_type);
+                    const size_t payload_bytes = body.size() - sizeof(ISMRMRD::ImageHeader);
+                    const size_t expected_bytes = mrd::element_type_bytes(element_type) *
+                                                  static_cast<size_t>(dims.spatial[0]) *
+                                                  static_cast<size_t>(dims.spatial[1]) *
+                                                  static_cast<size_t>(dims.spatial[2] ? dims.spatial[2] : 1) *
+                                                  static_cast<size_t>(dims.channels);
+                    if (payload_bytes != expected_bytes)
+                        throw std::runtime_error("payload size does not match header");
+
+                    std::string header_xml = mrd::default_ismrmrd_header(dims, element_type, stream_header);
+                    const void *payload = body.data() + sizeof(ISMRMRD::ImageHeader);
+
+                    auto result = state.swmr->append_frame(stream_header, dims, element_type, header_xml, payload, payload_bytes);
+
+                    json resp = {
+                        {"status", "ok"},
+                        {"path", result.file_path.string()},
+                        {"stream", result.stream_id},
+                        {"frame_index", result.frame_index},
+                        {"ts", result.timestamp},
+                        {"dims", {result.dims.spatial[0], result.dims.spatial[1], result.dims.spatial[2]}},
+                        {"channels", result.dims.channels},
+                        {"datatype", mrd::element_type_to_string(result.element_type)},
+                        {"size_bytes", result.bytes}};
+
+                    http::response<http::string_body> res{http::status::ok, req.version()};
+                    res.set(http::field::content_type, "application/json");
+                    res.body() = resp.dump();
+                    res.prepare_payload();
+                    return respond(std::move(res));
+                }
+                catch (const std::exception &e)
+                {
+                    http::response<http::string_body> res{http::status::bad_request, req.version()};
+                    res.set(http::field::content_type, "application/json");
+                    res.body() = json{{"error", e.what()}}.dump();
+                    res.prepare_payload();
+                    return respond(std::move(res));
+                }
             }
 
             // POST /v1/mrd/ingest  (writes ${data_dir}/mrd/*.mrd and updates index/latest)

--- a/src/marshal_main.cpp
+++ b/src/marshal_main.cpp
@@ -17,6 +17,7 @@
 #include "marshal_ws.hpp"
 #include "marshal_state.hpp"
 #include "mrd_io.hpp"
+#include "swmr_writer.hpp"
 
 namespace fs = std::filesystem;
 
@@ -91,6 +92,8 @@ int main(int argc, char **argv)
                       << " failed: " << ec.message() << "\n";
         }
     }
+
+    state.swmr = std::make_shared<mrd::SwmrManager>(state);
 
     // Networking endpoints
     boost::asio::ip::tcp::endpoint http_ep{boost::asio::ip::make_address(http_host), http_port};

--- a/src/marshal_state.hpp
+++ b/src/marshal_state.hpp
@@ -20,6 +20,11 @@
 #include <boost/asio.hpp>
 #include <nlohmann/json.hpp>
 #include "common/pose.hpp"
+
+namespace mrd
+{
+class SwmrManager;
+}
 enum class SinkMode
 {
     MRD,
@@ -59,4 +64,6 @@ struct MarshalState
     // Optional topic-based emit hook (set by WsServer on init).
     std::function<void(const std::string &, const std::string &topic)> ws_emit_topic =
         [](const std::string &, const std::string &) {};
+
+    std::shared_ptr<mrd::SwmrManager> swmr;
 };

--- a/src/swmr_writer.cpp
+++ b/src/swmr_writer.cpp
@@ -1,0 +1,458 @@
+#include "swmr_writer.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <stdexcept>
+#include <string_view>
+#include <sstream>
+
+#include "mrd_io.hpp"
+#include <ismrmrd/ismrmrd.h>
+
+namespace mrd
+{
+namespace
+{
+hid_t element_hdf_type(ElementType type)
+{
+    switch (type)
+    {
+    case ElementType::Float32:
+        return H5T_IEEE_F32LE;
+    case ElementType::UInt16:
+        return H5T_STD_U16LE;
+    }
+    throw std::runtime_error("unsupported element type");
+}
+
+} // namespace
+
+SwmrFile::SwmrFile(const std::filesystem::path &path,
+                   const std::string &stream_id,
+                   ElementType type,
+                   const StreamDimensions &dims,
+                   std::string header_xml)
+    : path_(path), stream_id_(stream_id), type_(type), dims_(dims), header_xml_(std::move(header_xml))
+{
+    if (dims_.spatial[0] == 0 || dims_.spatial[1] == 0 || dims_.channels == 0)
+        throw std::runtime_error("invalid SWMR dimensions");
+    if (dims_.spatial[2] == 0)
+        dims_.spatial[2] = 1;
+    frame_bytes_ = element_type_bytes(type_) * static_cast<size_t>(dims_.spatial[0]) *
+                   static_cast<size_t>(dims_.spatial[1]) * static_cast<size_t>(dims_.spatial[2]) *
+                   static_cast<size_t>(dims_.channels);
+    open();
+}
+
+SwmrFile::~SwmrFile()
+{
+    close();
+}
+
+void SwmrFile::open()
+{
+    namespace fs = std::filesystem;
+    fs::create_directories(path_.parent_path());
+
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    if (fapl < 0)
+        throw std::runtime_error("H5Pcreate failed");
+
+    if (H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST) < 0)
+    {
+        H5Pclose(fapl);
+        throw std::runtime_error("H5Pset_libver_bounds failed");
+    }
+
+    if (H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI) < 0)
+    {
+        H5Pclose(fapl);
+        throw std::runtime_error("H5Pset_fclose_degree failed");
+    }
+
+    file_ = H5Fcreate(path_.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+    H5Pclose(fapl);
+    if (file_ < 0)
+        throw std::runtime_error("H5Fcreate failed");
+
+    // Minimal ISMRMRD layout
+    hid_t dataset_group = H5Gcreate2(file_, "/dataset", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (dataset_group < 0)
+    {
+        close();
+        throw std::runtime_error("H5Gcreate2(/dataset) failed");
+    }
+    H5Gclose(dataset_group);
+
+    hid_t images_group = H5Gcreate2(file_, "/dataset/images", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (images_group < 0)
+    {
+        close();
+        throw std::runtime_error("H5Gcreate2(/dataset/images) failed");
+    }
+    H5Gclose(images_group);
+
+    // Scalar dataset for XML header
+    hid_t header_space = H5Screate(H5S_SCALAR);
+    if (header_space < 0)
+    {
+        close();
+        throw std::runtime_error("H5Screate header failed");
+    }
+    hid_t str_type = H5Tcopy(H5T_C_S1);
+    if (str_type < 0)
+    {
+        H5Sclose(header_space);
+        close();
+        throw std::runtime_error("H5Tcopy failed");
+    }
+    H5Tset_size(str_type, header_xml_.size() + 1);
+    H5Tset_strpad(str_type, H5T_STR_NULLTERM);
+    hid_t header_dset = H5Dcreate2(file_, "/dataset/header", str_type, header_space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    if (header_dset < 0)
+    {
+        H5Tclose(str_type);
+        H5Sclose(header_space);
+        close();
+        throw std::runtime_error("H5Dcreate2(/dataset/header) failed");
+    }
+    if (H5Dwrite(header_dset, str_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, header_xml_.c_str()) < 0)
+    {
+        H5Dclose(header_dset);
+        H5Tclose(str_type);
+        H5Sclose(header_space);
+        close();
+        throw std::runtime_error("H5Dwrite(/dataset/header) failed");
+    }
+    H5Dclose(header_dset);
+    H5Tclose(str_type);
+    H5Sclose(header_space);
+
+    const hsize_t z = dims_.spatial[2];
+    hsize_t initial_dims[5] = {0, dims_.channels, z, dims_.spatial[1], dims_.spatial[0]};
+    hsize_t max_dims[5] = {H5S_UNLIMITED, dims_.channels, z, dims_.spatial[1], dims_.spatial[0]};
+    hsize_t chunk[5] = {1, dims_.channels, z, dims_.spatial[1], dims_.spatial[0]};
+
+    hid_t space = H5Screate_simple(5, initial_dims, max_dims);
+    if (space < 0)
+    {
+        close();
+        throw std::runtime_error("H5Screate_simple failed");
+    }
+
+    hid_t dcpl = H5Pcreate(H5P_DATASET_CREATE);
+    if (dcpl < 0)
+    {
+        H5Sclose(space);
+        close();
+        throw std::runtime_error("H5Pcreate (dcpl) failed");
+    }
+
+    if (H5Pset_chunk(dcpl, 5, chunk) < 0 ||
+        H5Pset_fill_time(dcpl, H5D_FILL_TIME_NEVER) < 0 ||
+        H5Pset_alloc_time(dcpl, H5D_ALLOC_TIME_EARLY) < 0)
+    {
+        H5Pclose(dcpl);
+        H5Sclose(space);
+        close();
+        throw std::runtime_error("chunk configuration failed");
+    }
+
+    dataset_ = H5Dcreate2(file_, "/dataset/images/data", element_hdf_type(type_), space, H5P_DEFAULT, dcpl, H5P_DEFAULT);
+    H5Pclose(dcpl);
+    H5Sclose(space);
+    if (dataset_ < 0)
+    {
+        close();
+        throw std::runtime_error("H5Dcreate2 failed");
+    }
+
+    if (H5Fflush(file_, H5F_SCOPE_GLOBAL) < 0)
+    {
+        close();
+        throw std::runtime_error("H5Fflush failed before SWMR start");
+    }
+
+    if (H5Fstart_swmr_write(file_) < 0)
+    {
+        close();
+        throw std::runtime_error("H5Fstart_swmr_write failed");
+    }
+
+    H5Fflush(file_, H5F_SCOPE_GLOBAL);
+}
+
+void SwmrFile::close()
+{
+    if (dataset_ >= 0)
+    {
+        H5Dclose(dataset_);
+        dataset_ = -1;
+    }
+    if (file_ >= 0)
+    {
+        H5Fflush(file_, H5F_SCOPE_GLOBAL);
+        H5Fclose(file_);
+        file_ = -1;
+    }
+}
+
+SwmrFrameResult SwmrFile::append_frame(const void *data, size_t bytes)
+{
+    std::lock_guard<std::mutex> guard(write_mutex_);
+    const size_t need = frame_bytes_;
+    if (bytes != need)
+        throw std::runtime_error("frame payload size mismatch");
+
+    hsize_t new_dims[5] = {frames_ + 1, dims_.channels, dims_.spatial[2],
+                           dims_.spatial[1], dims_.spatial[0]};
+    if (H5Dset_extent(dataset_, new_dims) < 0)
+        throw std::runtime_error("H5Dset_extent failed");
+
+    hid_t filespace = H5Dget_space(dataset_);
+    if (filespace < 0)
+        throw std::runtime_error("H5Dget_space failed");
+
+    hsize_t start[5] = {frames_, 0, 0, 0, 0};
+    hsize_t count[5] = {1, dims_.channels, new_dims[2], new_dims[3], new_dims[4]};
+    if (H5Sselect_hyperslab(filespace, H5S_SELECT_SET, start, nullptr, count, nullptr) < 0)
+    {
+        H5Sclose(filespace);
+        throw std::runtime_error("H5Sselect_hyperslab failed");
+    }
+
+    hid_t memspace = H5Screate_simple(5, count, nullptr);
+    if (memspace < 0)
+    {
+        H5Sclose(filespace);
+        throw std::runtime_error("H5Screate_simple (mem) failed");
+    }
+
+    if (H5Dwrite(dataset_, element_hdf_type(type_), memspace, filespace, H5P_DEFAULT, data) < 0)
+    {
+        H5Sclose(memspace);
+        H5Sclose(filespace);
+        throw std::runtime_error("H5Dwrite failed");
+    }
+
+    H5Sclose(memspace);
+    H5Sclose(filespace);
+
+    if (H5Dflush(dataset_) < 0)
+        throw std::runtime_error("H5Dflush failed");
+    if (H5Fflush(file_, H5F_SCOPE_GLOBAL) < 0)
+        throw std::runtime_error("H5 flush failed");
+
+    SwmrFrameResult result;
+    result.file_path = path_;
+    result.stream_id = stream_id_;
+    result.frame_index = frames_;
+    result.bytes = bytes;
+    result.element_type = type_;
+    result.dims = dims_;
+    result.timestamp = iso8601_now_ms();
+
+    frames_++;
+    return result;
+}
+
+SwmrManager::SwmrManager(MarshalState &state)
+    : state_(state)
+{
+}
+
+std::shared_ptr<SwmrManager::StreamState> SwmrManager::ensure_stream(const std::string &stream_id,
+                                                                     const StreamDimensions &dims,
+                                                                     ElementType type,
+                                                                     const std::filesystem::path &sink_root,
+                                                                     std::string_view header_xml)
+{
+    std::lock_guard<std::mutex> guard(map_mutex_);
+    auto it = streams_.find(stream_id);
+    if (it != streams_.end())
+    {
+        auto state = it->second;
+        if (state->dims.spatial != dims.spatial || state->dims.channels != dims.channels || state->type != type)
+            throw std::runtime_error("stream dimensions/type mismatch");
+        return state;
+    }
+
+    auto clean = sanitize_stream(stream_id);
+    const std::string ts = iso8601_now_ms();
+    std::filesystem::path file_path = sink_root / (ts + "_" + clean + ".mrd");
+
+    auto state = std::make_shared<StreamState>();
+    state->dims = dims;
+    state->type = type;
+    state->header_xml = std::string(header_xml);
+    state->file = std::make_unique<SwmrFile>(file_path, stream_id, type, dims, state->header_xml);
+
+    streams_.emplace(stream_id, state);
+    return state;
+}
+
+SwmrFrameResult SwmrManager::append_frame(const std::string &stream_id,
+                                          const StreamDimensions &dims,
+                                          ElementType type,
+                                          std::string_view header_xml,
+                                          const void *data,
+                                          size_t bytes)
+{
+    auto sink = resolve_sink_paths(state_);
+    auto stream_state = ensure_stream(stream_id, dims, type, sink.sink_root, header_xml);
+
+    std::lock_guard<std::mutex> guard(stream_state->mutex);
+    if (!header_xml.empty() && stream_state->header_xml != header_xml)
+    {
+        // Keep the initial header string to avoid needless rewrites, but do enforce equality
+        if (stream_state->header_xml.empty())
+        {
+            stream_state->header_xml.assign(header_xml);
+        }
+        else if (stream_state->header_xml != header_xml)
+        {
+            throw std::runtime_error("stream header mismatch");
+        }
+    }
+    auto result = stream_state->file->append_frame(data, bytes);
+
+    auto seq = ingest_sequence().fetch_add(1);
+    nlohmann::json entry = make_entry_json(result);
+    entry["seq"] = seq;
+
+    append_line(sink.index_root / "index.jsonl", entry.dump());
+    const std::string latest = entry.dump();
+    write_atomic(sink.index_root / "latest.json", latest.data(), latest.size());
+
+    try
+    {
+        state_.ws_emit(entry.dump());
+        state_.ws_emit_topic(entry.dump(), "mrd.swmr");
+    }
+    catch (...)
+    {
+    }
+
+    return result;
+}
+
+std::string SwmrManager::sanitize_stream(const std::string &stream_id)
+{
+    std::string out;
+    out.reserve(stream_id.size());
+    for (char c : stream_id)
+    {
+        if (std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_')
+            out.push_back(c);
+        else
+            out.push_back('_');
+    }
+    if (out.empty())
+        out = "stream";
+    return out;
+}
+
+std::string SwmrManager::element_type_string(ElementType t)
+{
+    return element_type_to_string(t);
+}
+
+nlohmann::json SwmrManager::make_entry_json(const SwmrFrameResult &result) const
+{
+    nlohmann::json dims_json = {
+        {"x", result.dims.spatial[0]},
+        {"y", result.dims.spatial[1]},
+        {"z", result.dims.spatial[2] ? result.dims.spatial[2] : 1},
+        {"channels", result.dims.channels}};
+
+    return {
+        {"type", "mrd.swmr"},
+        {"path", result.file_path.string()},
+        {"stream", result.stream_id},
+        {"ts", result.timestamp},
+        {"frame_index", result.frame_index},
+        {"element_type", element_type_string(result.element_type)},
+        {"dims", dims_json},
+        {"size_bytes", result.bytes}};
+}
+
+ElementType parse_element_type(const std::string &value)
+{
+    if (value == "float32" || value == "float" || value == "f32")
+        return ElementType::Float32;
+    if (value == "uint16" || value == "u16")
+        return ElementType::UInt16;
+    throw std::runtime_error("unsupported element type: " + value);
+}
+
+std::string element_type_to_string(ElementType type)
+{
+    switch (type)
+    {
+    case ElementType::Float32:
+        return "float32";
+    case ElementType::UInt16:
+        return "uint16";
+    }
+    return "unknown";
+}
+
+size_t element_type_bytes(ElementType type)
+{
+    switch (type)
+    {
+    case ElementType::Float32:
+        return sizeof(float);
+    case ElementType::UInt16:
+        return sizeof(uint16_t);
+    }
+    throw std::runtime_error("unsupported element type");
+}
+
+ElementType element_type_from_ismrmrd(uint16_t data_type)
+{
+    switch (data_type)
+    {
+    case ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_FLOAT:
+        return ElementType::Float32;
+    case ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_USHORT:
+        return ElementType::UInt16;
+    default:
+        throw std::runtime_error("unsupported ISMRMRD image data_type");
+    }
+}
+
+std::string default_ismrmrd_header(const StreamDimensions &dims, ElementType, std::string_view stream_id)
+{
+    auto safe = stream_id.empty() ? std::string("stream") : std::string(stream_id);
+    std::ostringstream oss;
+    oss << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    oss << "<ismrmrdHeader xmlns=\"http://www.ismrm.org/ISMRMRD\">\n";
+    oss << "  <experimentalConditions>\n";
+    oss << "    <H1resonanceFrequency_Hz>123000000</H1resonanceFrequency_Hz>\n";
+    oss << "  </experimentalConditions>\n";
+    oss << "  <acquisitionSystemInformation>\n";
+    oss << "    <systemVendor>CWRU</systemVendor>\n";
+    oss << "    <systemModel>marshal</systemModel>\n";
+    oss << "  </acquisitionSystemInformation>\n";
+    oss << "  <encoding>\n";
+    oss << "    <encodedSpace>\n";
+    const auto z = dims.spatial[2] ? dims.spatial[2] : static_cast<hsize_t>(1);
+    oss << "      <matrixSize><x>" << dims.spatial[0] << "</x><y>" << dims.spatial[1] << "</y><z>" << z << "</z></matrixSize>\n";
+    oss << "      <fieldOfView_mm><x>1</x><y>1</y><z>1</z></fieldOfView_mm>\n";
+    oss << "    </encodedSpace>\n";
+    oss << "    <reconSpace>\n";
+    oss << "      <matrixSize><x>" << dims.spatial[0] << "</x><y>" << dims.spatial[1] << "</y><z>" << z << "</z></matrixSize>\n";
+    oss << "      <fieldOfView_mm><x>1</x><y>1</y><z>1</z></fieldOfView_mm>\n";
+    oss << "    </reconSpace>\n";
+    oss << "    <trajectory>cartesian</trajectory>\n";
+    oss << "  </encoding>\n";
+    oss << "  <measurementInformation>\n";
+    oss << "    <measurementID>" << safe << "</measurementID>\n";
+    oss << "  </measurementInformation>\n";
+    oss << "</ismrmrdHeader>";
+    return oss.str();
+}
+
+} // namespace mrd

--- a/tests/test_swmr_writer.cpp
+++ b/tests/test_swmr_writer.cpp
@@ -1,0 +1,98 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include <filesystem>
+#include <vector>
+#include <random>
+#include <string>
+#include <hdf5.h>
+
+#include "swmr_writer.hpp"
+#include "mrd_io.hpp"
+
+namespace fs = std::filesystem;
+
+static std::string unique_temp_dir()
+{
+    auto base = fs::temp_directory_path();
+    std::string name = "cwru_marshal_test_" + std::to_string(std::random_device{}());
+    fs::path full = base / name;
+    fs::create_directories(full);
+    return full.string();
+}
+
+TEST_CASE("SWMR writer appends frames visible to readers", "[swmr]")
+{
+    std::string temp = unique_temp_dir();
+    fs::path data_dir = fs::path(temp) / "data";
+    fs::create_directories(data_dir / "mrd");
+
+    MarshalState state;
+    state.data_dir = data_dir.string();
+    state.sink_mode = SinkMode::MRD;
+    state.ws_emit = [](const std::string &) {};
+    state.ws_emit_topic = [](const std::string &, const std::string &) {};
+
+    mrd::SwmrManager mgr(state);
+
+    mrd::StreamDimensions dims;
+    dims.spatial = {4, 3, 1};
+    dims.channels = 2;
+
+    const size_t elements = static_cast<size_t>(dims.spatial[0]) * dims.spatial[1] * dims.channels;
+    std::vector<float> frame1(elements, 1.5f);
+    std::vector<float> frame2(elements, 2.5f);
+
+    auto header_xml = mrd::default_ismrmrd_header(dims, mrd::ElementType::Float32, "streamA");
+    auto result1 = mgr.append_frame("streamA", dims, mrd::ElementType::Float32, header_xml, frame1.data(), frame1.size() * sizeof(float));
+    REQUIRE(result1.frame_index == 0);
+
+    auto result2 = mgr.append_frame("streamA", dims, mrd::ElementType::Float32, header_xml, frame2.data(), frame2.size() * sizeof(float));
+    REQUIRE(result2.frame_index == 1);
+    REQUIRE(result1.file_path == result2.file_path);
+
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    REQUIRE(fapl >= 0);
+    H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI);
+    hid_t file = H5Fopen(result2.file_path.c_str(), H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+    H5Pclose(fapl);
+    REQUIRE(file >= 0);
+
+    hid_t dset = H5Dopen2(file, "/dataset/images/data", H5P_DEFAULT);
+    REQUIRE(dset >= 0);
+    hid_t space = H5Dget_space(dset);
+    REQUIRE(space >= 0);
+    hsize_t dims_out[5] = {0};
+    H5Sget_simple_extent_dims(space, dims_out, nullptr);
+    CHECK(dims_out[0] == 2);
+    CHECK(dims_out[1] == dims.channels);
+    CHECK(dims_out[3] == dims.spatial[1]);
+    CHECK(dims_out[4] == dims.spatial[0]);
+
+    std::vector<float> readback(elements * 2);
+    hid_t memspace = H5Screate_simple(5, dims_out, nullptr);
+    REQUIRE(memspace >= 0);
+    REQUIRE(H5Dread(dset, H5T_IEEE_F32LE, memspace, space, H5P_DEFAULT, readback.data()) >= 0);
+    H5Sclose(memspace);
+    H5Sclose(space);
+    H5Dclose(dset);
+
+    hid_t header_dset = H5Dopen2(file, "/dataset/header", H5P_DEFAULT);
+    REQUIRE(header_dset >= 0);
+    hid_t header_type = H5Dget_type(header_dset);
+    REQUIRE(header_type >= 0);
+    size_t header_size = H5Tget_size(header_type);
+    std::vector<char> xml(header_size, '\0');
+    REQUIRE(H5Dread(header_dset, header_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, xml.data()) >= 0);
+    H5Tclose(header_type);
+    H5Dclose(header_dset);
+
+    H5Fclose(file);
+
+    for (size_t i = 0; i < elements; ++i)
+    {
+        CHECK(readback[i] == Catch::Approx(frame1[i]));
+        CHECK(readback[i + elements] == Catch::Approx(frame2[i]));
+    }
+    CHECK(std::string(xml.data()) == header_xml);
+}


### PR DESCRIPTION
## Summary
- rewrite the SWMR writer to create standard /dataset/header and /dataset/images/data layouts and flush writes for SWMR readers
- add a /v1/ismrmrd/frame endpoint that parses ISMRMRD image headers before appending frames to the active scan
- refresh docs, viz_client, and regression tests to open MRDs in SWMR-read mode and describe the new ingestion workflow

## Testing
- cmake -S . -B build -G Ninja *(fails: Boost headers are not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4544e34e483329e6eb8f166c4a4f3