### PR TITLE
Add int16 support to MRD frame ingestion

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -82,6 +82,7 @@ Binary concatenation of:
 Supported datatypes are:
 
 - Real `float32`
+- Signed `int16`
 - Unsigned `uint16`
 - Complex `complex64` (two `float32` values per voxel)
 

--- a/include/mrd_sink.hpp
+++ b/include/mrd_sink.hpp
@@ -22,6 +22,7 @@ namespace mrd
 enum class ElementType
 {
     Float32,
+    Int16,
     UInt16,
     ComplexFloat32
 };

--- a/src/mrd_sink.cpp
+++ b/src/mrd_sink.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <cstdint>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
@@ -20,6 +21,8 @@ hid_t element_hdf_type(ElementType type)
     {
     case ElementType::Float32:
         return H5T_IEEE_F32LE;
+    case ElementType::Int16:
+        return H5T_STD_I16LE;
     case ElementType::UInt16:
         return H5T_STD_U16LE;
     case ElementType::ComplexFloat32:
@@ -390,6 +393,8 @@ ElementType parse_element_type(const std::string &value)
 {
     if (value == "float32" || value == "float" || value == "f32")
         return ElementType::Float32;
+    if (value == "int16" || value == "i16" || value == "short")
+        return ElementType::Int16;
     if (value == "uint16" || value == "u16")
         return ElementType::UInt16;
     if (value == "complex64" || value == "cfloat" || value == "cf32")
@@ -403,6 +408,8 @@ std::string element_type_to_string(ElementType type)
     {
     case ElementType::Float32:
         return "float32";
+    case ElementType::Int16:
+        return "int16";
     case ElementType::UInt16:
         return "uint16";
     case ElementType::ComplexFloat32:
@@ -417,6 +424,8 @@ size_t element_type_bytes(ElementType type)
     {
     case ElementType::Float32:
         return sizeof(float);
+    case ElementType::Int16:
+        return sizeof(int16_t);
     case ElementType::UInt16:
         return sizeof(uint16_t);
     case ElementType::ComplexFloat32:
@@ -431,6 +440,8 @@ ElementType element_type_from_ismrmrd(uint16_t data_type)
     {
     case ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_FLOAT:
         return ElementType::Float32;
+    case ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_SHORT:
+        return ElementType::Int16;
     case ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_USHORT:
         return ElementType::UInt16;
     case ISMRMRD::ISMRMRD_DataTypes::ISMRMRD_CXFLOAT:

--- a/tests/test_mrd_sink.cpp
+++ b/tests/test_mrd_sink.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <random>
 #include <string>
+#include <cstdint>
 #include <hdf5.h>
 
 #include "mrd_sink.hpp"
@@ -175,4 +176,65 @@ TEST_CASE("MRD sink handles complex64 payloads", "[mrd][complex]")
         CHECK(readback[i].r == Catch::Approx(frame[i].r));
         CHECK(readback[i].i == Catch::Approx(frame[i].i));
     }
+}
+
+TEST_CASE("MRD sink handles int16 payloads", "[mrd][int16]")
+{
+    std::string temp = unique_temp_dir();
+    fs::path data_dir = fs::path(temp) / "data";
+    fs::create_directories(data_dir / "mrd");
+
+    MarshalState state;
+    state.data_dir = data_dir.string();
+    state.sink_mode = SinkMode::MRD;
+    state.ws_emit = [](const std::string &) {};
+    state.ws_emit_topic = [](const std::string &, const std::string &) {};
+
+    mrd::MrdSink sink(state);
+
+    mrd::ImageDimensions dims;
+    dims.spatial = {3, 2, 1};
+    dims.channels = 1;
+
+    const size_t elements = static_cast<size_t>(dims.spatial[0]) * dims.spatial[1] * dims.channels;
+    std::vector<int16_t> frame(elements);
+    for (size_t i = 0; i < elements; ++i)
+        frame[i] = static_cast<int16_t>(i * 7 - 3);
+
+    auto header_xml = mrd::default_ismrmrd_header(dims, mrd::ElementType::Int16, "streamI16");
+    auto result = sink.append_frame("streamI16", dims, mrd::ElementType::Int16, header_xml, frame.data(), frame.size() * sizeof(int16_t));
+    REQUIRE(result.frame_index == 0);
+
+    hid_t fapl = H5Pcreate(H5P_FILE_ACCESS);
+    REQUIRE(fapl >= 0);
+    H5Pset_libver_bounds(fapl, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+    H5Pset_fclose_degree(fapl, H5F_CLOSE_SEMI);
+    hid_t file = H5Fopen(result.file_path.c_str(), H5F_ACC_RDONLY | H5F_ACC_SWMR_READ, fapl);
+    H5Pclose(fapl);
+    REQUIRE(file >= 0);
+
+    hid_t dset = H5Dopen2(file, "/images/data", H5P_DEFAULT);
+    REQUIRE(dset >= 0);
+    REQUIRE(H5Drefresh(dset) >= 0);
+
+    hid_t space = H5Dget_space(dset);
+    REQUIRE(space >= 0);
+    hsize_t dims_out[5] = {0};
+    H5Sget_simple_extent_dims(space, dims_out, nullptr);
+    CHECK(dims_out[0] == 1);
+    CHECK(dims_out[1] == dims.channels);
+    CHECK(dims_out[3] == dims.spatial[1]);
+    CHECK(dims_out[4] == dims.spatial[0]);
+
+    std::vector<int16_t> readback(elements);
+    hid_t memspace = H5Screate_simple(5, dims_out, nullptr);
+    REQUIRE(memspace >= 0);
+    REQUIRE(H5Dread(dset, H5T_STD_I16LE, memspace, space, H5P_DEFAULT, readback.data()) >= 0);
+    H5Sclose(memspace);
+    H5Sclose(space);
+    H5Dclose(dset);
+    H5Fclose(file);
+
+    for (size_t i = 0; i < elements; ++i)
+        CHECK(readback[i] == frame[i]);
 }


### PR DESCRIPTION
## Summary
- add a signed 16-bit element type to the MRD sink and map it to the ISMRMRD short image datatype
- expose the new type through the HTTP frame ingestion path and document the additional support option
- cover the new payload format with a regression test exercising HDF5 SWMR write/read

## Testing
- cmake -S . -B build *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR system))*

------
https://chatgpt.com/codex/tasks/task_e_68e51314e7b88332a94622dc0820ffaa