### PR TITLE
Add OpenCV visualization and pose overlay to viz_client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,9 @@ endif()
 #message(STATUS "HDF5 library dirs: ${HDF5_LIBRARY_DIRS}")
 message(STATUS "HDF5 libraries: ${HDF5_LIBRARIES}")
 
+# OpenCV (for viz_client image display)
+find_package(OpenCV REQUIRED COMPONENTS core imgproc highgui)
+
 # JSON
 include(FetchContent)
 FetchContent_Declare(nlohmann_json GIT_REPOSITORY https://github.com/nlohmann/json.git GIT_TAG v3.11.3)
@@ -72,7 +75,8 @@ add_executable(fk_client clients/fk_client/fk_client_main.cpp)
 target_link_libraries(fk_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json)
 
 add_executable(viz_client clients/viz_client/viz_client_main.cpp)
-target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target})
+target_include_directories(viz_client PRIVATE ${OpenCV_INCLUDE_DIRS})
+target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target} ${OpenCV_LIBS})
 
 add_executable(image_streamer clients/image_streamer/image_streamer_main.cpp)
 target_link_libraries(image_streamer PRIVATE Boost::system Threads::Threads ${ismrmrd_target})

--- a/clients/viz_client/viz_client_main.cpp
+++ b/clients/viz_client/viz_client_main.cpp
@@ -3,6 +3,12 @@
 #include <fstream>
 #include <thread>
 #include <chrono>
+#include <mutex>
+#include <deque>
+#include <sstream>
+#include <iomanip>
+#include <array>
+#include <atomic>
 #include <boost/asio.hpp>
 #include <boost/beast/websocket.hpp>
 #include <nlohmann/json.hpp>
@@ -11,12 +17,15 @@
 #include <vector>
 #include <algorithm>
 #include <limits>
+#include <cmath>
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/highgui.hpp>
 
 using json = nlohmann::json;
 namespace fs = std::filesystem;
 namespace websocket = boost::beast::websocket;
 
-// add near the top, after includes
 static std::time_t file_time_to_time_t(std::filesystem::file_time_type t)
 {
     using namespace std::chrono;
@@ -26,40 +35,271 @@ static std::time_t file_time_to_time_t(std::filesystem::file_time_type t)
     return system_clock::to_time_t(sctp);
 }
 
-static void render_ascii(const std::vector<float> &voxels,
-                         size_t nx,
-                         size_t ny,
-                         size_t nz,
-                         size_t frame_idx)
+struct PoseHistory
 {
-    static const std::string palette = " .:-=+*#%@";
-    auto [min_it, max_it] = std::minmax_element(voxels.begin(), voxels.end());
-    float min_v = (min_it != voxels.end()) ? *min_it : 0.f;
-    float max_v = (max_it != voxels.end()) ? *max_it : 1.f;
-    float span = std::max(1e-6f, max_v - min_v);
+    std::deque<cv::Point3d> points;
+    double min_x = 0.0;
+    double max_x = 0.0;
+    double min_y = 0.0;
+    double max_y = 0.0;
+    bool has_bounds = false;
+};
 
-    std::cout << "\n=== Frame " << frame_idx + 1 << " (" << nz << " slices) ===\n";
+static std::mutex g_viz_mutex;
+static cv::Mat g_latest_image;
+static PoseHistory g_pose_history;
+static std::array<double, 3> g_last_pose{0.0, 0.0, 0.0};
+static bool g_has_pose = false;
+static std::string g_status_text;
+static constexpr size_t kMaxPoseTrail = 256;
+static std::atomic<bool> g_display_running{true};
+
+static void recompute_pose_bounds(PoseHistory &history)
+{
+    if (history.points.empty())
+    {
+        history.min_x = history.max_x = 0.0;
+        history.min_y = history.max_y = 0.0;
+        history.has_bounds = false;
+        return;
+    }
+
+    history.min_x = history.max_x = history.points.front().x;
+    history.min_y = history.max_y = history.points.front().y;
+    for (const auto &pt : history.points)
+    {
+        history.min_x = std::min(history.min_x, pt.x);
+        history.max_x = std::max(history.max_x, pt.x);
+        history.min_y = std::min(history.min_y, pt.y);
+        history.max_y = std::max(history.max_y, pt.y);
+    }
+    history.has_bounds = true;
+}
+
+static void record_pose_point(double x, double y, double z)
+{
+    std::scoped_lock lk(g_viz_mutex);
+    auto &history = g_pose_history;
+    history.points.emplace_back(x, y, z);
+    if (!history.has_bounds)
+    {
+        history.min_x = history.max_x = x;
+        history.min_y = history.max_y = y;
+        history.has_bounds = true;
+    }
+    else
+    {
+        history.min_x = std::min(history.min_x, x);
+        history.max_x = std::max(history.max_x, x);
+        history.min_y = std::min(history.min_y, y);
+        history.max_y = std::max(history.max_y, y);
+    }
+
+    if (history.points.size() > kMaxPoseTrail)
+    {
+        history.points.pop_front();
+        recompute_pose_bounds(history);
+    }
+
+    g_last_pose = {x, y, z};
+    g_has_pose = true;
+}
+
+static void record_pose_from_json(const json &j)
+{
+    if (!j.contains("p") || !j["p"].is_array())
+        return;
+    const auto &arr = j["p"];
+    if (arr.size() < 2)
+        return;
+    double x = arr[0].get<double>();
+    double y = arr[1].get<double>();
+    double z = (arr.size() > 2) ? arr[2].get<double>() : 0.0;
+    record_pose_point(x, y, z);
+}
+
+static void update_volume_image(const std::vector<float> &voxels,
+                                size_t nx,
+                                size_t ny,
+                                size_t nz,
+                                size_t frame_idx,
+                                size_t frame_count)
+{
+    if (voxels.empty() || nx == 0 || ny == 0)
+        return;
+
+    std::vector<float> projection(nx * ny, std::numeric_limits<float>::lowest());
     for (size_t z = 0; z < nz; ++z)
     {
-        std::cout << "Slice " << (z + 1) << "/" << nz << "\n";
         for (size_t y = 0; y < ny; ++y)
         {
-            std::string line;
-            line.reserve(nx);
             for (size_t x = 0; x < nx; ++x)
             {
                 size_t idx = z * ny * nx + y * nx + x;
-                float norm = (voxels[idx] - min_v) / span;
-                size_t palette_idx = static_cast<size_t>(norm * (palette.size() - 1));
-                if (palette_idx >= palette.size())
-                    palette_idx = palette.size() - 1;
-                line.push_back(palette[palette_idx]);
+                auto &dst = projection[y * nx + x];
+                dst = std::max(dst, voxels[idx]);
             }
-            std::cout << line << '\n';
         }
-        std::cout << '\n';
     }
-    std::cout.flush();
+
+    auto [min_it, max_it] = std::minmax_element(projection.begin(), projection.end());
+    float min_v = (min_it != projection.end()) ? *min_it : 0.f;
+    float max_v = (max_it != projection.end()) ? *max_it : 1.f;
+    float span = std::max(1e-6f, max_v - min_v);
+
+    cv::Mat gray(static_cast<int>(ny), static_cast<int>(nx), CV_8UC1);
+    for (size_t y = 0; y < ny; ++y)
+    {
+        auto *row = gray.ptr<uint8_t>(static_cast<int>(y));
+        for (size_t x = 0; x < nx; ++x)
+        {
+            float norm = (projection[y * nx + x] - min_v) / span;
+            norm = std::clamp(norm, 0.0f, 1.0f);
+            row[x] = static_cast<uint8_t>(norm * 255.f);
+        }
+    }
+
+    cv::Mat bgr;
+    cv::cvtColor(gray, bgr, cv::COLOR_GRAY2BGR);
+
+    std::ostringstream oss;
+    oss << "Frame " << (frame_idx + 1) << "/" << frame_count
+        << "  size=" << nx << "x" << ny << "x" << nz
+        << "  max-projection"
+        << "  intensity=[" << std::fixed << std::setprecision(3)
+        << min_v << ", " << max_v << "]";
+
+    {
+        std::scoped_lock lk(g_viz_mutex);
+        g_latest_image = std::move(bgr);
+        g_status_text = oss.str();
+    }
+}
+
+static bool project_pose_to_frame(const cv::Point3d &pt,
+                                  const PoseHistory &history,
+                                  const cv::Mat &frame,
+                                  cv::Point &out)
+{
+    if (frame.empty() || !history.has_bounds)
+        return false;
+
+    double range_x = history.max_x - history.min_x;
+    double range_y = history.max_y - history.min_y;
+    if (std::abs(range_x) < 1e-9)
+        range_x = 1.0;
+    if (std::abs(range_y) < 1e-9)
+        range_y = 1.0;
+
+    double norm_x = (pt.x - history.min_x) / range_x;
+    double norm_y = (pt.y - history.min_y) / range_y;
+    norm_x = std::clamp(norm_x, 0.0, 1.0);
+    norm_y = std::clamp(norm_y, 0.0, 1.0);
+
+    int width = std::max(frame.cols, 1);
+    int height = std::max(frame.rows, 1);
+    int px = static_cast<int>(norm_x * (width - 1));
+    int py = static_cast<int>((1.0 - norm_y) * (height - 1));
+    px = std::clamp(px, 0, width - 1);
+    py = std::clamp(py, 0, height - 1);
+    out = {px, py};
+    return true;
+}
+
+static void draw_pose_overlay(cv::Mat &frame, const PoseHistory &history)
+{
+    if (frame.empty() || history.points.empty() || !history.has_bounds)
+        return;
+
+    cv::Point prev;
+    bool first = true;
+    size_t count = history.points.size();
+    size_t idx = 0;
+    for (const auto &pt : history.points)
+    {
+        cv::Point curr;
+        if (!project_pose_to_frame(pt, history, frame, curr))
+            return;
+
+        if (!first)
+        {
+            double alpha = (count > 1) ? static_cast<double>(idx) / (count - 1) : 1.0;
+            cv::Scalar color(0, static_cast<int>(255 * (1.0 - alpha)), static_cast<int>(255 * alpha));
+            cv::line(frame, prev, curr, color, 2, cv::LINE_AA);
+        }
+
+        prev = curr;
+        first = false;
+        ++idx;
+    }
+
+    cv::circle(frame, prev, 5, cv::Scalar(0, 0, 255), -1, cv::LINE_AA);
+}
+
+static void display_loop()
+{
+    cv::namedWindow("viz_client", cv::WINDOW_AUTOSIZE);
+
+    while (g_display_running.load())
+    {
+        cv::Mat frame;
+        PoseHistory history_snapshot;
+        std::string status;
+        std::array<double, 3> pose{};
+        bool has_pose = false;
+
+        {
+            std::scoped_lock lk(g_viz_mutex);
+            if (!g_latest_image.empty())
+                g_latest_image.copyTo(frame);
+            history_snapshot = g_pose_history;
+            status = g_status_text;
+            pose = g_last_pose;
+            has_pose = g_has_pose;
+        }
+
+        if (frame.empty())
+        {
+            frame = cv::Mat::zeros(240, 320, CV_8UC3);
+            cv::putText(frame, "Waiting for MRD frames...", cv::Point(10, 120),
+                        cv::FONT_HERSHEY_SIMPLEX, 0.5, cv::Scalar(200, 200, 200), 1, cv::LINE_AA);
+        }
+        else
+        {
+            draw_pose_overlay(frame, history_snapshot);
+            if (!status.empty())
+            {
+                cv::putText(frame, status, cv::Point(10, 20), cv::FONT_HERSHEY_SIMPLEX, 0.45,
+                            cv::Scalar(0, 0, 0), 2, cv::LINE_AA);
+                cv::putText(frame, status, cv::Point(10, 20), cv::FONT_HERSHEY_SIMPLEX, 0.45,
+                            cv::Scalar(255, 255, 255), 1, cv::LINE_AA);
+            }
+            if (has_pose)
+            {
+                std::ostringstream oss;
+                oss << std::fixed << std::setprecision(2)
+                    << "Pose p=[" << pose[0] << ", " << pose[1] << ", " << pose[2] << "]";
+                auto text = oss.str();
+                int baseline = 0;
+                auto size = cv::getTextSize(text, cv::FONT_HERSHEY_SIMPLEX, 0.45, 1, &baseline);
+                cv::Point origin(10, std::max(frame.rows - 10, size.height + 10));
+                cv::putText(frame, text, origin, cv::FONT_HERSHEY_SIMPLEX, 0.45,
+                            cv::Scalar(0, 0, 0), 2, cv::LINE_AA);
+                cv::putText(frame, text, origin, cv::FONT_HERSHEY_SIMPLEX, 0.45,
+                            cv::Scalar(0, 255, 0), 1, cv::LINE_AA);
+            }
+        }
+
+        cv::imshow("viz_client", frame);
+
+        int key = cv::waitKey(30);
+        if (key == 27) // ESC
+        {
+            g_display_running.store(false);
+        }
+    }
+
+    cv::destroyWindow("viz_client");
 }
 
 static void inspect_swmr_file(const std::string &path)
@@ -125,7 +365,7 @@ static void inspect_swmr_file(const std::string &path)
                 }
                 if (H5Dread(dset, H5T_NATIVE_FLOAT, memspace, space, H5P_DEFAULT, voxels.data()) >= 0)
                 {
-                    render_ascii(voxels, nx, ny, nz, frames - 1);
+                    update_volume_image(voxels, nx, ny, nz, frames - 1, frames);
                 }
                 else
                 {
@@ -159,6 +399,8 @@ int main(int argc, char **argv)
             data = argv[++i];
     }
 
+    std::thread display_thread(display_loop);
+
     fs::path latest = fs::path(data) / "latest.json";
     if (!fs::exists(latest))
     {
@@ -171,14 +413,18 @@ int main(int argc, char **argv)
     std::thread poll([&]()
                      {
         std::time_t last = 0;
-        while (true) {
-            try {
-                    if (fs::exists(latest)) {
-                   // auto wt = decltype(fs::last_write_time(latest))::clock::to_time_t(fs::last_write_time(latest));
-                   auto wt = file_time_to_time_t(fs::last_write_time(latest));
-                   if (wt != last) {
+        while (g_display_running.load())
+        {
+            try
+            {
+                if (fs::exists(latest))
+                {
+                    auto wt = file_time_to_time_t(fs::last_write_time(latest));
+                    if (wt != last)
+                    {
                         std::ifstream lf(latest);
-                        json lj; lf >> lj;
+                        json lj;
+                        lf >> lj;
                         std::cout << "viz latest=" << lj.dump() << "\n";
                         if (lj.contains("frame_index") && lj.contains("path"))
                         {
@@ -193,9 +439,13 @@ int main(int argc, char **argv)
                         last = wt;
                     }
                 }
-            } catch (...) {}
+            }
+            catch (...)
+            {
+            }
             std::this_thread::sleep_for(std::chrono::seconds(1));
-        } });
+        }
+    });
 
     // --- Connect WS once, print until closed ---
     try
@@ -217,7 +467,7 @@ int main(int argc, char **argv)
 
         std::cout << "viz: WS connected " << ws_url << "\n";
         boost::beast::flat_buffer buf;
-        while (true)
+        while (g_display_running.load())
         {
             boost::system::error_code ec;
             ws.read(buf, ec);
@@ -232,6 +482,20 @@ int main(int argc, char **argv)
             if (j.is_object())
             {
                 std::cout << "viz ws: " << j.dump() << "\n";
+                if (j.contains("type") && j["type"].is_string())
+                {
+                    auto type = j["type"].get<std::string>();
+                    if (type == "pose")
+                    {
+                        try
+                        {
+                            record_pose_from_json(j);
+                        }
+                        catch (...)
+                        {
+                        }
+                    }
+                }
                 if (j.contains("frame_index") && j.contains("path"))
                 {
                     try
@@ -250,6 +514,10 @@ int main(int argc, char **argv)
         std::cerr << "viz: WS error: " << e.what() << "\n";
     }
 
-    poll.join();
+    g_display_running.store(false);
+    if (poll.joinable())
+        poll.join();
+    if (display_thread.joinable())
+        display_thread.join();
     return 0;
 }


### PR DESCRIPTION
## Summary
- replace the ASCII slice dump with an OpenCV window that renders a max-intensity projection for the latest MRD frame
- draw the pose history from the FK client on top of the image and annotate the view with frame and pose metadata
- link viz_client against OpenCV so the new highgui-based visualization can build

## Testing
- `cmake -S . -B build` *(fails: Boost 1.74 development files are not present in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54ddb96bc83329f0e18ae8a0a075d