### PR TITLE
Ensure viz client OpenCV viz component is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ if(DEFINED CACHE{ENABLE_VIZ_CLIENT})
 endif()
 option(ENABLE_VIZ_CLIENT "Build viz_client (requires OpenCV)" ON)
 if(ENABLE_VIZ_CLIENT)
+  unset(_opencv_link_targets)
+  unset(_opencv_link_mode)
+  unset(_opencv_has_viz)
   find_package(OpenCV 4 QUIET COMPONENTS core imgproc highgui viz)
   if(NOT OpenCV_FOUND)
     if(_viz_client_option_was_cached)
@@ -52,7 +55,29 @@ if(ENABLE_VIZ_CLIENT)
       set(ENABLE_VIZ_CLIENT OFF)
     endif()
   else()
-    message(STATUS "Found OpenCV: ${OpenCV_VERSION} (components: ${OpenCV_LIBS})")
+    if(TARGET OpenCV::opencv_viz)
+      set(_opencv_link_targets
+        OpenCV::opencv_core
+        OpenCV::opencv_imgproc
+        OpenCV::opencv_highgui
+        OpenCV::opencv_viz)
+      set(_opencv_link_mode "targets")
+    elseif(OpenCV_LIBS)
+      set(_opencv_has_viz FALSE)
+      foreach(_opencv_lib IN LISTS OpenCV_LIBS)
+        if(_opencv_lib MATCHES "opencv_viz")
+          set(_opencv_has_viz TRUE)
+          break()
+        endif()
+      endforeach()
+      if(NOT _opencv_has_viz)
+        message(FATAL_ERROR "OpenCV found, but the viz component was not present in OpenCV_LIBS. Check your OpenCV installation.")
+      endif()
+      set(_opencv_link_mode "libraries")
+    else()
+      message(FATAL_ERROR "OpenCV was found, but no imported targets or library list were exported. Unable to link viz_client.")
+    endif()
+    message(STATUS "Found OpenCV: ${OpenCV_VERSION} (linking via ${_opencv_link_mode})")
   endif()
 endif()
 
@@ -94,19 +119,21 @@ target_link_libraries(fk_client PRIVATE Boost::system Threads::Threads nlohmann_
 
 if(ENABLE_VIZ_CLIENT)
   add_executable(viz_client clients/viz_client/viz_client_main.cpp)
-  if(TARGET OpenCV::opencv_core)
+  if(DEFINED _opencv_link_targets)
     target_link_libraries(viz_client PRIVATE
       Boost::system
       Threads::Threads
       nlohmann_json::nlohmann_json
       ${hdf5_target}
-      OpenCV::opencv_core
-      OpenCV::opencv_imgproc
-      OpenCV::opencv_highgui
-      OpenCV::opencv_viz)
+      ${_opencv_link_targets})
   else()
     target_include_directories(viz_client PRIVATE ${OpenCV_INCLUDE_DIRS})
-    target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target} ${OpenCV_LIBS})
+    target_link_libraries(viz_client PRIVATE
+      Boost::system
+      Threads::Threads
+      nlohmann_json::nlohmann_json
+      ${hdf5_target}
+      ${OpenCV_LIBS})
   endif()
 else()
   message(STATUS "viz_client disabled (ENABLE_VIZ_CLIENT=OFF)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(DEFINED CACHE{ENABLE_VIZ_CLIENT})
 endif()
 option(ENABLE_VIZ_CLIENT "Build viz_client (requires OpenCV)" ON)
 if(ENABLE_VIZ_CLIENT)
-  find_package(OpenCV QUIET COMPONENTS core imgproc highgui)
+  find_package(OpenCV 4 QUIET COMPONENTS core imgproc highgui viz)
   if(NOT OpenCV_FOUND)
     if(_viz_client_option_was_cached)
       message(FATAL_ERROR "ENABLE_VIZ_CLIENT is ON but OpenCV was not found. Provide OpenCV or disable the viz client.")
@@ -51,6 +51,8 @@ if(ENABLE_VIZ_CLIENT)
       set(ENABLE_VIZ_CLIENT OFF CACHE BOOL "Build viz_client (requires OpenCV)" FORCE)
       set(ENABLE_VIZ_CLIENT OFF)
     endif()
+  else()
+    message(STATUS "Found OpenCV: ${OpenCV_VERSION} (components: ${OpenCV_LIBS})")
   endif()
 endif()
 
@@ -92,8 +94,20 @@ target_link_libraries(fk_client PRIVATE Boost::system Threads::Threads nlohmann_
 
 if(ENABLE_VIZ_CLIENT)
   add_executable(viz_client clients/viz_client/viz_client_main.cpp)
-  target_include_directories(viz_client PRIVATE ${OpenCV_INCLUDE_DIRS})
-  target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target} ${OpenCV_LIBS})
+  if(TARGET OpenCV::opencv_core)
+    target_link_libraries(viz_client PRIVATE
+      Boost::system
+      Threads::Threads
+      nlohmann_json::nlohmann_json
+      ${hdf5_target}
+      OpenCV::opencv_core
+      OpenCV::opencv_imgproc
+      OpenCV::opencv_highgui
+      OpenCV::opencv_viz)
+  else()
+    target_include_directories(viz_client PRIVATE ${OpenCV_INCLUDE_DIRS})
+    target_link_libraries(viz_client PRIVATE Boost::system Threads::Threads nlohmann_json::nlohmann_json ${hdf5_target} ${OpenCV_LIBS})
+  endif()
 else()
   message(STATUS "viz_client disabled (ENABLE_VIZ_CLIENT=OFF)")
 endif()

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -8,4 +8,7 @@
 - viz_client disabled because OpenCV is missing: install `libopencv-dev libopencv-viz-dev`
   in addition to the core dependencies above, then rerun `cmake -S . -B build` (and rebuild with
   `cmake --build build --target viz_client`). If OpenCV is installed in a non-standard
-  prefix, set `OpenCV_DIR` to the folder containing `OpenCVConfig.cmake`.
+  prefix, set `OpenCV_DIR` to the folder containing `OpenCVConfig.cmake`. The `libopencv-dev`
+  meta package is what provides `OpenCVConfig.cmake`; the devcontainer/Docker images still add the
+  split `libopencv-*-dev` packages so we get the viz GUI bits without pulling in every optional
+  OpenCV module via `Recommends`.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -5,3 +5,7 @@
 - latest.json missing: verify ingest path writes index & latest atomically.
 - CMake can't find Boost/HDF5/ISMRMRD: install `libboost-all-dev libhdf5-dev libismrmrd-dev`
   (Ubuntu/Debian) or make sure the SDK paths are exported via `CMAKE_PREFIX_PATH`.
+- viz_client disabled because OpenCV is missing: install `libopencv-dev libopencv-viz-dev`
+  in addition to the core dependencies above, then rerun `cmake -S . -B build` (and rebuild with
+  `cmake --build build --target viz_client`). If OpenCV is installed in a non-standard
+  prefix, set `OpenCV_DIR` to the folder containing `OpenCVConfig.cmake`.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
   libopencv-highgui-dev \
   libopencv-imgcodecs-dev \
   libopencv-imgproc-dev \
+  libopencv-viz-dev \
   libpugixml-dev \
   python3 \
   python3-pip \
@@ -116,6 +117,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libopencv-highgui406t64 \
   libopencv-imgcodecs406t64 \
   libopencv-imgproc406t64 \
+  libopencv-viz406t64 \
   python3 \
   python3-pip \
   && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -116,11 +116,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libboost-filesystem1.74.0 \
   libboost-thread1.74.0 \
   libboost-program-options1.74.0 \
-  libopencv-core406t64 \
-  libopencv-highgui406t64 \
-  libopencv-imgcodecs406t64 \
-  libopencv-imgproc406t64 \
-  libopencv-viz406t64 \
+  # Jammy (22.04) ships OpenCV 4.5 runtimes under the "4.5d" suffix.
+  libopencv-core4.5d \
+  libopencv-highgui4.5d \
+  libopencv-imgcodecs4.5d \
+  libopencv-imgproc4.5d \
+  libopencv-viz4.5d \
   python3 \
   python3-pip \
   && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update && \
   libboost-program-options-dev \
   libboost-system-dev \
   libboost-thread-dev \
+  # libopencv-dev ships OpenCVConfig.cmake, the split packages pull in viz + GUI bits without
+  # dragging every optional OpenCV module via Recommends.
+  libopencv-dev \
   libopencv-core-dev \
   libopencv-highgui-dev \
   libopencv-imgcodecs-dev \


### PR DESCRIPTION
## Summary
- require the OpenCV viz component when building viz_client and link against its imported target
- install libopencv-viz packages in the devcontainer and Docker runtime images
- document the additional viz dependency in the troubleshooting guide

## Testing
- cmake -S . -B build *(fails: Boost headers are not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55ffa496c8332beeb61e44064bce7