### PR TITLE
Fix SWMR client startup wait and HTTP keep-alive handling

### DIFF
--- a/clients/viz_client/viz_client_main.cpp
+++ b/clients/viz_client/viz_client_main.cpp
@@ -646,11 +646,7 @@ int main(int argc, char **argv)
 
     fs::path latest = fs::path(data) / "latest.json";
     if (!fs::exists(latest))
-    {
-        std::cerr << "viz: waiting for latest.json...\n";
-        while (!fs::exists(latest))
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
+        std::cerr << "viz: latest.json not found yet; waiting for frames while continuing setup...\n";
 
     // --- Poll latest.json forever ---
     std::thread poll([&]()

--- a/src/marshal_http.hpp
+++ b/src/marshal_http.hpp
@@ -123,6 +123,7 @@ private:
                         res.set(http::field::content_type, "application/json");
                         res.body() = json{{"error", "request body exceeds limit"}, {"limit_bytes", kMaxHttpBodyBytes}}.dump();
                         res.prepare_payload();
+                        res.keep_alive(false);
                         self->respond(std::move(res));
                     }
                     return;
@@ -132,17 +133,27 @@ private:
                 self->handle(); });
         }
 
-        // FIX: keep response alive through async_write
         void respond(http::response<http::string_body> &&res)
         {
             auto self = shared_from_this();
+            const bool keep_alive = req.keep_alive() && res.keep_alive();
             auto sp = std::make_shared<http::response<http::string_body>>(std::move(res));
             sp->set(http::field::server, "marshal-beast");
+            sp->keep_alive(keep_alive);
 
-            http::async_write(socket, *sp, [self, sp](boost::beast::error_code, std::size_t)
+            http::async_write(socket, *sp, [self, sp, keep_alive](boost::beast::error_code, std::size_t)
                               {
                 boost::system::error_code ignored;
-                self->socket.shutdown(boost::asio::ip::tcp::socket::shutdown_send, ignored); });
+                if (keep_alive)
+                {
+                    self->do_read();
+                }
+                else
+                {
+                    self->socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored);
+                    self->socket.close(ignored);
+                }
+            });
         }
 
         // crude parser for ?ts=…&limit=…


### PR DESCRIPTION
## Summary
- allow viz_client to continue initialization even when latest.json has not been created yet so pose updates still reach the display
- update marshal HTTP session responses to respect keep-alive requests, preventing premature socket shutdowns and repeated reconnects

## Testing
- `cmake -S . -B build` *(fails: missing Boost headers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e824b0a3c883328eb73578ad505e11